### PR TITLE
Add Auction Gem reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,8 @@ gem 'spree_gateway', github: 'spree/spree_gateway', branch: '3-0-stable'
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: '3-0-stable'
 gem 'spree_i18n', git: 'git://github.com/spree/spree_i18n.git', branch: '3-0-stable'
 gem 'deface', git: 'git://github.com/spree/deface.git', branch: 'master'
-gem 'spree_px_auction', git: "https://49887dcddfed712f0ae9a296756a31df77ae0d1e:x-oauth-basic@github.com/PromoExchange/spree_px_auction.git"
+# gem 'spree_px_auction', git: "https://49887dcddfed712f0ae9a296756a31df77ae0d1e:x-oauth-basic@github.com/PromoExchange/spree_px_auction.git"
+gem 'spree_px_auction', :path => '../spree_px_auction'
 
 gem 'aws-sdk'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 
 GIT
   remote: git://github.com/spree/spree_auth_devise.git
-  revision: 347428395b8c06c79c3bfe516404314a1c365839
+  revision: d2ee454e21746094d6e0bc79b9d4421b5849c20e
   branch: 3-0-stable
   specs:
     spree_auth_devise (3.0.0)
@@ -42,9 +42,8 @@ GIT
       rails-i18n (~> 4.0.1)
       spree_core (~> 3.0.0)
 
-GIT
-  remote: https://49887dcddfed712f0ae9a296756a31df77ae0d1e:x-oauth-basic@github.com/PromoExchange/spree_px_auction.git
-  revision: fc9ccfcd2ebe4c2f6b0a79d2ef97a7761d014b6e
+PATH
+  remote: ../spree_px_auction
   specs:
     spree_px_auction (3.0.1)
       spree_core (~> 3.0.1)
@@ -257,7 +256,7 @@ GEM
     kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
-    letter_opener (1.3.0)
+    letter_opener (1.4.0)
       launchy (~> 2.2)
     listen (2.10.0)
       celluloid (~> 0.16.0)
@@ -480,9 +479,9 @@ GEM
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.0.3)
+    sprockets (3.1.0)
       rack (~> 1.0)
-    sprockets-rails (2.3.0)
+    sprockets-rails (2.3.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)

--- a/db/migrate/20150512201325_create_auction_table.spree_px_auction.rb
+++ b/db/migrate/20150512201325_create_auction_table.spree_px_auction.rb
@@ -1,0 +1,14 @@
+# This migration comes from spree_px_auction (originally 20150512174605)
+class CreateAuctionTable < ActiveRecord::Migration
+  def change
+    create_table :spree_auctions do |t|
+      t.integer :product_id
+      t.integer :seller_id
+      t.integer :bidder_id
+      t.string :descripiton
+      t.datetime :started
+      t.datetime :ended
+      t.decimal :bid
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150509235521) do
+ActiveRecord::Schema.define(version: 20150512201325) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "auction", force: :cascade do |t|
+    t.integer  "product_id"
+    t.integer  "seller_id"
+    t.integer  "bidder_id"
+    t.string   "descripiton"
+    t.datetime "started"
+    t.datetime "ended"
+    t.decimal  "bid"
+  end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string   "slug",                      null: false
@@ -91,6 +101,26 @@ ActiveRecord::Schema.define(version: 20150509235521) do
 
   add_index "spree_assets", ["viewable_id"], name: "index_assets_on_viewable_id", using: :btree
   add_index "spree_assets", ["viewable_type", "type"], name: "index_assets_on_viewable_type_and_type", using: :btree
+
+  create_table "spree_auction", force: :cascade do |t|
+    t.integer  "product_id"
+    t.integer  "seller_id"
+    t.integer  "bidder_id"
+    t.string   "descripiton"
+    t.datetime "started"
+    t.datetime "ended"
+    t.decimal  "bid"
+  end
+
+  create_table "spree_auctions", force: :cascade do |t|
+    t.integer  "product_id"
+    t.integer  "seller_id"
+    t.integer  "bidder_id"
+    t.string   "descripiton"
+    t.datetime "started"
+    t.datetime "ended"
+    t.decimal  "bid"
+  end
 
   create_table "spree_calculators", force: :cascade do |t|
     t.string   "type"

--- a/vendor/assets/javascripts/spree/backend/all.js
+++ b/vendor/assets/javascripts/spree/backend/all.js
@@ -10,3 +10,4 @@
 
 //= require_tree .
 //= require spree/backend/spree_first_data_gge4
+//= require spree/backend/spree_px_auction

--- a/vendor/assets/javascripts/spree/frontend/all.js
+++ b/vendor/assets/javascripts/spree/frontend/all.js
@@ -10,3 +10,4 @@
 
 //= require_tree .
 //= require spree/frontend/spree_first_data_gge4
+//= require spree/frontend/spree_px_auction

--- a/vendor/assets/stylesheets/spree/backend/all.css
+++ b/vendor/assets/stylesheets/spree/backend/all.css
@@ -8,4 +8,5 @@
  *= require_self
  *= require_tree .
  *= require spree/backend/spree_first_data_gge4
+ *= require spree/backend/spree_px_auction
 */

--- a/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/vendor/assets/stylesheets/spree/frontend/all.css
@@ -8,4 +8,5 @@
  *= require_self
  *= require_tree .
  *= require spree/frontend/spree_first_data_gge4
+ *= require spree/frontend/spree_px_auction
 */


### PR DESCRIPTION
Adds the spree_px_auction gem to the bundle.
Installed from the private git repo
Uses a deployment key, as per heroku recommendations
