### PR TITLE
Bump auction extension migrations and assets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GIT
 
 GIT
   remote: https://49887dcddfed712f0ae9a296756a31df77ae0d1e:x-oauth-basic@github.com/PromoExchange/spree_px_auction.git
-  revision: b4887f6183ff466e4ea779166c180ed436cdaeb9
+  revision: 828471e82f7de0ef39ddc2448ccb16fa2182f561
   branch: master
   specs:
     spree_px_auction (3.0.1)

--- a/db/migrate/20150521204056_create_auction_table.spree_px_auction.rb
+++ b/db/migrate/20150521204056_create_auction_table.spree_px_auction.rb
@@ -2,13 +2,15 @@
 class CreateAuctionTable < ActiveRecord::Migration
   def change
     create_table :spree_auctions do |t|
-      t.integer :product_id
-      t.integer :seller_id
-      t.integer :bidder_id
+      t.integer :product_id, null: false
+      t.integer :seller_id, null: false
+      t.integer :bidder_id, null: false
       t.string :descripiton
       t.datetime :started
       t.datetime :ended
       t.decimal :bid
+
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20150521204057_rename_columns_on_spree_auction.spree_px_auction.rb
+++ b/db/migrate/20150521204057_rename_columns_on_spree_auction.spree_px_auction.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree_px_auction (originally 20150514212059)
+class RenameColumnsOnSpreeAuction < ActiveRecord::Migration
+  def change
+    rename_column :spree_auctions, :bidder_id, :buyer_id
+    rename_column :spree_auctions, :descripiton, :description
+  end
+end

--- a/db/migrate/20150521204058_create_bids.spree_px_auction.rb
+++ b/db/migrate/20150521204058_create_bids.spree_px_auction.rb
@@ -1,0 +1,13 @@
+# This migration comes from spree_px_auction (originally 20150519234457)
+class CreateBids < ActiveRecord::Migration
+  def change
+    create_table :spree_bids do |t|
+      t.integer :auction_id, null: false
+      t.integer :seller_id, null: false
+      t.string :description
+      t.decimal :bid, precision: 8, scale: 2, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150521204059_remove_seller_id_from_auctions.spree_px_auction.rb
+++ b/db/migrate/20150521204059_remove_seller_id_from_auctions.spree_px_auction.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree_px_auction (originally 20150520160326)
+class RemoveSellerIdFromAuctions < ActiveRecord::Migration
+  def change
+    remove_column :spree_auctions, :seller_id, :integer
+  end
+end

--- a/db/migrate/20150521204060_remove_bid_from_auctions.spree_px_auction.rb
+++ b/db/migrate/20150521204060_remove_bid_from_auctions.spree_px_auction.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree_px_auction (originally 20150520160412)
+class RemoveBidFromAuctions < ActiveRecord::Migration
+  def change
+    remove_column :spree_auctions, :bid, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150512201325) do
+ActiveRecord::Schema.define(version: 20150521204060) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "auction", force: :cascade do |t|
-    t.integer  "product_id"
-    t.integer  "seller_id"
-    t.integer  "bidder_id"
-    t.string   "descripiton"
-    t.datetime "started"
-    t.datetime "ended"
-    t.decimal  "bid"
-  end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
     t.string   "slug",                      null: false
@@ -102,24 +92,23 @@ ActiveRecord::Schema.define(version: 20150512201325) do
   add_index "spree_assets", ["viewable_id"], name: "index_assets_on_viewable_id", using: :btree
   add_index "spree_assets", ["viewable_type", "type"], name: "index_assets_on_viewable_type_and_type", using: :btree
 
-  create_table "spree_auction", force: :cascade do |t|
-    t.integer  "product_id"
-    t.integer  "seller_id"
-    t.integer  "bidder_id"
-    t.string   "descripiton"
+  create_table "spree_auctions", force: :cascade do |t|
+    t.integer  "product_id",  null: false
+    t.integer  "buyer_id",    null: false
+    t.string   "description"
     t.datetime "started"
     t.datetime "ended"
-    t.decimal  "bid"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
-  create_table "spree_auctions", force: :cascade do |t|
-    t.integer  "product_id"
-    t.integer  "seller_id"
-    t.integer  "bidder_id"
-    t.string   "descripiton"
-    t.datetime "started"
-    t.datetime "ended"
-    t.decimal  "bid"
+  create_table "spree_bids", force: :cascade do |t|
+    t.integer  "auction_id",                          null: false
+    t.integer  "seller_id",                           null: false
+    t.string   "description"
+    t.decimal  "bid",         precision: 8, scale: 2, null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
   end
 
   create_table "spree_calculators", force: :cascade do |t|


### PR DESCRIPTION
This PR brings the development branch up to date with the latest version of the auction extension. 
This help stop sync issues, especially around migrations.

:clipboard: 
1. Run the migrations `bundle exec rake db:migrate`
2. Confirm `spree_auction` and `spree_bid` tables are created

:notebook:

:checkered_flag:
