### PR TITLE
Added supplier model

### DIFF
--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,4 +1,6 @@
 Spree::Product.class_eval do
+  belongs_to :supplier, class_name: 'Spree::Supplier', inverse_of: :products
+
   def all_prices
     price_ranges = Spree::Variant.where(product_id: id).first.volume_prices[0...-1].map(&:range)
     volume_prices = Spree::Variant.where(product_id: id).first.volume_prices[0...-1].map(&:amount).map(&:to_f)

--- a/app/models/spree/supplier.rb
+++ b/app/models/spree/supplier.rb
@@ -1,0 +1,6 @@
+module Spree
+  class Supplier < Spree::Base
+    belongs_to :address, class_name: 'Spree::Address', inverse_of: :suppliers
+    has_many :products, class_name: 'Spree::Product', inverse_of: :supplier
+  end
+end

--- a/db/migrate/20150525213913_create_suppliers.rb
+++ b/db/migrate/20150525213913_create_suppliers.rb
@@ -1,0 +1,11 @@
+class CreateSuppliers < ActiveRecord::Migration
+  def change
+    create_table :spree_suppliers do |t|
+      t.integer :address_id
+      t.string :name
+      t.string :description
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150525215641_add_supplier_id_to_product.rb
+++ b/db/migrate/20150525215641_add_supplier_id_to_product.rb
@@ -1,0 +1,5 @@
+class AddSupplierIdToProduct < ActiveRecord::Migration
+  def change
+    add_column :spree_products, :supplier_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150525140520) do
+ActiveRecord::Schema.define(version: 20150525215641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -506,6 +506,7 @@ ActiveRecord::Schema.define(version: 20150525140520) do
     t.datetime "updated_at",                          null: false
     t.boolean  "promotionable",        default: true
     t.string   "meta_title"
+    t.integer  "supplier_id"
   end
 
   add_index "spree_products", ["available_on"], name: "index_spree_products_on_available_on", using: :btree
@@ -946,6 +947,14 @@ ActiveRecord::Schema.define(version: 20150525140520) do
   add_index "spree_stores", ["code"], name: "index_spree_stores_on_code", using: :btree
   add_index "spree_stores", ["default"], name: "index_spree_stores_on_default", using: :btree
   add_index "spree_stores", ["url"], name: "index_spree_stores_on_url", using: :btree
+
+  create_table "spree_suppliers", force: :cascade do |t|
+    t.integer  "address_id"
+    t.string   "name"
+    t.string   "description"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "spree_tax_categories", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
@PromoExchange/engineers 

:notebook: 
- Added supplier model.
- A supplier has a name, description, address, and products
- This relationship will become important to use to make PMS color conversions and the such
- I did not create an api for this model or a way to add it from the admin panel. If you see this as important, we can do that

:clipboard: 
1. Run `rake db:migrate`
2. From the console, try to create a supplier and relate some products to it.
