### PR TITLE
Base Bower install plus bootstrap color picker

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,3 @@
+# vim .buildpacks
+https://github.com/heroku/heroku-buildpack-nodejs.git#v60
+https://github.com/heroku/heroku-buildpack-ruby.git#v127

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 
 public/assets/**
 public/spree/**
+
+/vendor/assets/bower_components

--- a/Bowerfile
+++ b/Bowerfile
@@ -1,0 +1,6 @@
+# A sample Bowerfile
+# Check out https://github.com/42dev/bower-rails#ruby-dsl-configuration for more options
+
+# asset 'bootstrap'
+
+asset 'bootstrap-colorpickersliders'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'pg'
 gem 'unicorn'
 gem 'font-awesome-sass'
+gem 'bower-rails'
 
 # spree ecommerce
 gem 'spree', '3.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     bootstrap-sass (3.3.4.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    bower-rails (0.9.2)
     builder (3.2.2)
     byebug (4.0.5)
       columnize (= 0.9.0)
@@ -563,6 +564,7 @@ DEPENDENCIES
   aws-sdk (~> 1.60.2)
   better_errors
   binding_of_caller
+  bower-rails
   capybara
   coffee-rails (~> 4.1.0)
   database_cleaner

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ module Batman
       end
     end
 
+    config.assets.paths << Rails.root.join("vendor","assets","bower_components")
+
     # Load all images in images sub directories
     Dir.glob("#{Rails.root}/app/assets/images/**/").each do |path|
       config.assets.paths << path

--- a/config/initializers/bower_rails.rb
+++ b/config/initializers/bower_rails.rb
@@ -1,0 +1,16 @@
+BowerRails.configure do |bower_rails|
+  # Tell bower-rails what path should be considered as root. Defaults to Dir.pwd
+  # bower_rails.root_path = Dir.pwd
+
+  # Invokes rake bower:install before precompilation. Defaults to false
+  # bower_rails.install_before_precompile = true
+
+  # Invokes rake bower:resolve before precompilation. Defaults to false
+  # bower_rails.resolve_before_precompile = true
+
+  # Invokes rake bower:clean before precompilation. Defaults to false
+  # bower_rails.clean_before_precompile = true
+  
+  # Invokes rake bower:install:deployment instead rake bower:install. Defaults to false
+  # bower_rails.use_bower_install_deployment = true
+end

--- a/vendor/assets/.bowerrc
+++ b/vendor/assets/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/vendor/assets/bower.json
+++ b/vendor/assets/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "dsl-generated dependencies",
+  "dependencies": {
+    "bootstrap-colorpickersliders": "latest"
+  },
+  "resolutions": {
+    "jquery": ">= 1.9.1"
+  }
+}


### PR DESCRIPTION
:clipboard: 
1. Run `bundle exec bower:install`
2. Select the lastest jQuery if asked
3. Check to see vendor/assets/bower_components is populated with
- bootstrap
- bootstrap-colorpickersliders
- jquery
  1. Navigate to `http://localhost:3000/` and ensure site is still operational

:notebook:
This PR only includes the bower scaffold and the bootstrap color picker slider. 
It does not have any UI yet. The UI will first appear in the auction extension.
I have included the heroku buildpacks as described here:

https://coderwall.com/p/6bmygq/heroku-rails-bower
