### PR TITLE
Discount codes added as extension to Spree::Price

### DIFF
--- a/app/models/spree/price_decorator.rb
+++ b/app/models/spree/price_decorator.rb
@@ -1,0 +1,33 @@
+Spree::Price.class_eval do
+  def self.discount_codes
+    {
+      A: 0.50,
+      B: 0.55,
+      C: 0.60,
+      D: 0.65,
+      E: 0.70,
+      F: 0.75,
+      G: 0.80,
+      H: 0.85,
+      I: 0.90,
+      J: 0.95,
+      K: 1.00,
+      P: 0.50,
+      Q: 0.55,
+      R: 0.60,
+      S: 0.65,
+      T: 0.70,
+      U: 0.75,
+      V: 0.80,
+      W: 0.85,
+      X: 0.90,
+      Y: 0.95,
+      Z: 1.00
+    }.freeze
+  end
+
+  def self.discount_price(code, price)
+    discount = Spree::Price.discount_codes[code.to_sym]
+    discount.nil? ? price : (price * discount)
+  end
+end

--- a/spec/models/spree/price_spec.rb
+++ b/spec/models/spree/price_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Spree::Price, type: :model do
+  it 'should have A discount by 50%' do
+    # setup
+    t = Spree::Price::discount_codes[:A]
+
+    # exercise
+    # verify
+    expect(t).to eq 0.50
+    # teardown
+  end
+
+  it 'should have Z discount by 100%' do
+    # setup
+    t = Spree::Price::discount_codes[:Z]
+
+    # exercise
+    # verify
+    expect(t).to eq 1.00
+    # teardown
+  end
+
+  it 'should discount price' do
+    # setup
+    t = Spree::Price.discount_price('A', 1200)
+
+    # exercise
+    # verify
+    expect(t).to eq 600
+    # teardown
+  end
+
+  it 'should not discount price' do
+    # setup
+    t = Spree::Price.discount_price('L', 100)
+
+    # exercise
+    # verify
+    expect(t).to eq 100
+    # teardown
+  end
+end


### PR DESCRIPTION
:clipboard: 
1. Run `rake` to run the tests, there should be no failures

:notebook:
Extends Spree::Price with 
- discount code values as a constant
- Added class method `discount_price`

:checkered_flag:
