### PR TITLE
Add Order Auction assoc. Constraints are temp removed because of samp…

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,0 +1,5 @@
+Spree::Order.class_eval do
+  belongs_to :auction
+  # TODO: Removed because sample data will not load
+  # validates :auction_id, presence: true
+end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,8 @@
 Spree::Product.class_eval do
   belongs_to :supplier, class_name: 'Spree::Supplier', inverse_of: :products
   has_and_belongs_to_many :imprint_methods
+  # TODO: Removed because sample data will not load
+  # validates :supplier_id, presence: true
 
   def all_prices
     price_ranges = Spree::Variant.where(product_id: id).first.volume_prices[0...-1].map(&:range)

--- a/db/migrate/20150529194832_add_auction_id_to_order.rb
+++ b/db/migrate/20150529194832_add_auction_id_to_order.rb
@@ -1,0 +1,5 @@
+class AddAuctionIdToOrder < ActiveRecord::Migration
+  def change
+    add_column :spree_orders, :auction_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -341,6 +341,7 @@ ActiveRecord::Schema.define(version: 20150529202817) do
     t.integer  "canceler_id"
     t.integer  "store_id"
     t.integer  "state_lock_version",                                         default: 0,       null: false
+    t.integer  "auction_id"
   end
 
   add_index "spree_orders", ["approver_id"], name: "index_spree_orders_on_approver_id", using: :btree

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Spree::Order, type: :model do
+  it 'should belong to an auction' do
+    # setup
+    t = Spree::Order.reflect_on_association(:auction)
+
+    # exercise
+    # verify
+    expect(t.macro).to eq :belongs_to
+    # teardown
+  end
+end


### PR DESCRIPTION
:clipboard: 
1. Run `bundle exec rake db:bootstrap`
2. Ensure sample data loads
3. Ensure the `spree_orders` table has a `auction_id` column

:notebook:

:checkered_flag:
