### PR TITLE
Table adjustments, prebid, bid and order

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GIT
 
 GIT
   remote: https://49887dcddfed712f0ae9a296756a31df77ae0d1e:x-oauth-basic@github.com/PromoExchange/spree_px_auction.git
-  revision: 671e6a37259b2d6ad15dd57ebe2eaf3fe993317e
+  revision: 9475aaa5d19fe140103e7abf1891f5d8356be348
   branch: master
   specs:
     spree_px_auction (3.0.1)

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,5 +1,3 @@
 Spree::Order.class_eval do
-  belongs_to :auction
-  # TODO: Removed because sample data will not load
-  # validates :auction_id, presence: true
+  has_one :bid
 end

--- a/db/migrate/20150601185756_remove_auction_id_from_order.rb
+++ b/db/migrate/20150601185756_remove_auction_id_from_order.rb
@@ -1,0 +1,5 @@
+class RemoveAuctionIdFromOrder < ActiveRecord::Migration
+  def change
+    remove_column :spree_orders, :auction_id
+  end
+end

--- a/db/migrate/20150602123136_add_order_to_bid.spree_px_auction.rb
+++ b/db/migrate/20150602123136_add_order_to_bid.spree_px_auction.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree_px_auction (originally 20150601182959)
+# This migration comes from spree_px_auction (originally 20150601182959)
+class AddOrderToBid < ActiveRecord::Migration
+  def change
+    add_column :spree_bids, :order_id, :integer
+  end
+end

--- a/db/migrate/20150602123137_add_prebid_to_bid.spree_px_auction.rb
+++ b/db/migrate/20150602123137_add_prebid_to_bid.spree_px_auction.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree_px_auction (originally 20150601183726)
+# This migration comes from spree_px_auction (originally 20150601183726)
+class AddPrebidToBid < ActiveRecord::Migration
+  def change
+    add_column :spree_bids, :prebid_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150601132841) do
+ActiveRecord::Schema.define(version: 20150602123137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,8 @@ ActiveRecord::Schema.define(version: 20150601132841) do
     t.decimal  "bid",         precision: 8, scale: 2, null: false
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
+    t.integer  "order_id"
+    t.integer  "prebid_id"
   end
 
   create_table "spree_calculators", force: :cascade do |t|
@@ -342,7 +344,6 @@ ActiveRecord::Schema.define(version: 20150601132841) do
     t.integer  "canceler_id"
     t.integer  "store_id"
     t.integer  "state_lock_version",                                         default: 0,       null: false
-    t.integer  "auction_id"
   end
 
   add_index "spree_orders", ["approver_id"], name: "index_spree_orders_on_approver_id", using: :btree

--- a/spec/models/spree/bid_spec.rb
+++ b/spec/models/spree/bid_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Spree::Bid, type: :model do
+  it 'should belong to an auction' do
+    # setup
+    t = Spree::Bid.reflect_on_association(:auction)
+
+    # exercise
+    # verify
+    expect(t.macro).to eq :belongs_to
+    # teardown
+  end
+
+  it 'should belong to an order' do
+    # setup
+    t = Spree::Bid.reflect_on_association(:order)
+
+    # exercise
+    # verify
+    expect(t.macro).to eq :belongs_to
+    # teardown
+  end
+
+  it 'should belong to prebid' do
+    # setup
+    t = Spree::Bid.reflect_on_association(:prebid)
+
+    # exercise
+    # verify
+    expect(t.macro).to eq :belongs_to
+    # teardown
+  end
+end

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Spree::Order, type: :model do
   it 'should belong to an auction' do
     # setup
-    t = Spree::Order.reflect_on_association(:auction)
+    t = Spree::Order.reflect_on_association(:bid)
 
     # exercise
     # verify
-    expect(t.macro).to eq :belongs_to
+    expect(t.macro).to eq :has_one
     # teardown
   end
 end

--- a/spec/models/spree/prebid_spec.rb
+++ b/spec/models/spree/prebid_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Spree::Prebid, type: :model do
+  it 'should have many bids' do
+    # setup
+    t = Spree::Prebid.reflect_on_association(:bids)
+
+    # exercise
+    # verify
+    expect(t.macro).to eq :has_many
+    # teardown
+  end
+
+  it 'should belong to user' do
+    # setup
+    t = Spree::Prebid.reflect_on_association(:user)
+
+    # exercise
+    # verify
+    expect(t.macro).to eq :belongs_to
+    # teardown
+  end
+
+  it 'should belong to a taxon' do
+    # setup
+    t = Spree::Prebid.reflect_on_association(:taxon)
+
+    # exercise
+    # verify
+    expect(t.macro).to eq :belongs_to
+    # teardown
+  end
+end


### PR DESCRIPTION
On hold for https://github.com/PromoExchange/spree_px_auction/pull/16
Once that has been merged I will sync  and push.

:clipboard: 
1. Run 'bundle exec db:bootstrap`
2. Ensure the following
- Spree::Order has one bid
- Spree::PreBid has many bids
- `spree_bid` has id columns for `order` and `prebid`

:notebook:

:checkered_flag:
