### PR TITLE
Prebid api

### DIFF
--- a/app/controllers/spree/api/auctions_controller.rb
+++ b/app/controllers/spree/api/auctions_controller.rb
@@ -13,6 +13,7 @@ class Spree::Api::AuctionsController < Spree::Api::BaseController
         .page(params[:page])
         .per(params[:per_page] || Spree::Config[:orders_per_page])
     end
+
     render 'spree/api/auctions/index'
   end
 

--- a/app/controllers/spree/api/bids_controller.rb
+++ b/app/controllers/spree/api/bids_controller.rb
@@ -13,6 +13,7 @@ class Spree::Api::BidsController < Spree::Api::BaseController
         .page(params[:page])
         .per(params[:per_page] || Spree::Config[:orders_per_page])
     end
+
     render 'spree/api/bids/index'
   end
 

--- a/app/controllers/spree/api/prebids_controller.rb
+++ b/app/controllers/spree/api/prebids_controller.rb
@@ -1,0 +1,63 @@
+class Spree::Api::PrebidsController < Spree::Api::BaseController
+  before_action :fetch_prebid, except: [:index, :create]
+
+  def index
+    if params[:buyer_id].present?
+      @prebids = Spree::Prebid.where(buyer_id: params[:buyer_id])
+        .page(params[:page])
+        .per(params[:per_page] || Spree::Config[:orders_per_page])
+    else
+      @prebids = Spree::Prebid.all
+        .page(params[:page])
+        .per(params[:per_page] || Spree::Config[:orders_per_page])
+    end
+
+    render 'spree/api/prebids/index'
+  end
+
+  def show
+    render 'spree/api/prebids/show'
+  end
+
+  def create
+    if @prebid.present?
+      render nothing: true, status: :conflict
+    else
+      @prebid = Spree::Prebid.new
+      save_prebid
+    end
+  end
+
+  def update
+    save_prebid
+  end
+
+  def destroy
+    @prebid.destroy
+    render nothing: true, status: :ok
+  end
+
+  private
+
+  def prebid_params
+    params.require(:prebid).permit(:taxon_id,
+      :seller_id,
+      :description,
+      :page,
+      :per_page)
+  end
+
+  def fetch_prebid
+    @prebid = Spree::Prebid.find(params[:id])
+  end
+
+  def save_prebid
+    @json = JSON.parse(request.body.read)
+    @prebid.assign_attributes(@json)
+    if @prebid.save
+      render 'spree/api/prebids/show'
+    else
+      render nothing: true, status: :bad_request
+    end
+  end
+end

--- a/app/helpers/spree/api/api_helpers_decorator.rb
+++ b/app/helpers/spree/api/api_helpers_decorator.rb
@@ -35,4 +35,12 @@ Spree::Api::ApiHelpers.module_eval do
       :prebid_id
     ])
   mattr_reader :bid_attributes
+
+  class_variable_set(:@@prebid_attributes,
+    [
+      :id,
+      :seller_id,
+      :description
+    ])
+  mattr_reader :prebid_attributes
 end

--- a/app/models/spree/prebid.rb
+++ b/app/models/spree/prebid.rb
@@ -1,9 +1,7 @@
 class Spree::Prebid < ActiveRecord::Base
   belongs_to :seller, class_name: 'User'
-  belongs_to :taxon
-  has_many :adjustments, as: :adjustable
+  has_many :adjustments
   has_many :bids
 
-  validates :taxon_id, presence: true
   validates :seller_id, presence: true
 end

--- a/app/views/spree/api/prebids/index.rabl
+++ b/app/views/spree/api/prebids/index.rabl
@@ -1,0 +1,2 @@
+collection @prebids
+attributes *prebid_attributes

--- a/app/views/spree/api/prebids/show.rabl
+++ b/app/views/spree/api/prebids/show.rabl
@@ -1,0 +1,2 @@
+object @prebid
+attributes *prebid_attributes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,4 +33,9 @@ Rails.application.routes.draw do
   put '/api/bids/:id', to: 'spree/api/bids#update', defaults: {format: 'json'}
   delete '/api/bids/:id', to: 'spree/api/bids#destroy', defaults: {format: 'json'}
 
+  get '/api/prebids', to: 'spree/api/prebids#index', defaults: {format: 'json'}
+  get '/api/prebids/:id', to: 'spree/api/prebids#show', defaults: {format: 'json'}
+  post '/api/prebids', to: 'spree/api/prebids#create', defaults: {format: 'json'}
+  put '/api/prebids/:id', to: 'spree/api/prebids#update', defaults: {format: 'json'}
+  delete '/api/prebids/:id', to: 'spree/api/prebids#destroy', defaults: {format: 'json'}
 end

--- a/db/migrate/20150608193556_remove_taxon_from_prebids.rb
+++ b/db/migrate/20150608193556_remove_taxon_from_prebids.rb
@@ -1,0 +1,5 @@
+class RemoveTaxonFromPrebids < ActiveRecord::Migration
+  def change
+    remove_column :spree_prebids, :taxon_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150606201809) do
+ActiveRecord::Schema.define(version: 20150608193556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -472,7 +472,6 @@ ActiveRecord::Schema.define(version: 20150606201809) do
   end
 
   create_table "spree_prebids", force: :cascade do |t|
-    t.integer  "taxon_id",    null: false
     t.integer  "seller_id",   null: false
     t.string   "description"
     t.datetime "created_at",  null: false

--- a/spec/factories/prebid.rb
+++ b/spec/factories/prebid.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :prebid, class: Spree::Prebid do
-    taxon
     association :seller, factory: :user
     description 'This is a test'
   end

--- a/spec/models/spree/prebid_spec.rb
+++ b/spec/models/spree/prebid_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Spree::Prebid, type: :model do
-  it 'should not save with a nil taxon' do
-    p = FactoryGirl.build(:prebid, taxon_id: nil)
-    expect(p.save).to be_falsey
-  end
-
   it 'should not save with a nil seller' do
     p = FactoryGirl.build(:prebid, seller_id: nil)
     expect(p.save).to be_falsey
@@ -23,11 +18,6 @@ RSpec.describe Spree::Prebid, type: :model do
 
   it 'should belong to user' do
     t = Spree::Prebid.reflect_on_association(:seller)
-    expect(t.macro).to eq :belongs_to
-  end
-
-  it 'should belong to a taxon' do
-    t = Spree::Prebid.reflect_on_association(:taxon)
     expect(t.macro).to eq :belongs_to
   end
 end

--- a/spec/requests/spree/auction_spec.rb
+++ b/spec/requests/spree/auction_spec.rb
@@ -25,6 +25,15 @@ describe 'Auctions API' do
     expect(json.length).to eq(10)
   end
 
+  it 'should get a page of auctions' do
+    FactoryGirl.create_list(:auction, 10)
+
+    get '/api/auctions?page=2&per_page=3', nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json.length).to eq(3)
+  end
+
   it 'should get a single auction' do
     auction = FactoryGirl.create(:auction)
 

--- a/spec/requests/spree/bid_spec.rb
+++ b/spec/requests/spree/bid_spec.rb
@@ -8,13 +8,24 @@ describe 'Bids API' do
     user
   end
 
-  it 'must require an api key' do
+  it 'must require an api key (nested)' do
     auction = FactoryGirl.build(:auction)
     bid = FactoryGirl.build(:bid)
     bid.auction_id = auction.id
     auction.save
 
     get "/api/auctions/#{auction.id}/bids"
+
+    expect(response).to have_http_status(401)
+  end
+
+  it 'must require an api key (root)' do
+    auction = FactoryGirl.build(:auction)
+    bid = FactoryGirl.build(:bid)
+    bid.auction_id = auction.id
+    auction.save
+
+    get "/api/bids"
 
     expect(response).to have_http_status(401)
   end
@@ -35,6 +46,15 @@ describe 'Bids API' do
 
     expect(response).to be_success
     expect(json.length).to eq(5)
+  end
+
+  it 'should gets a page of bids' do
+    FactoryGirl.create_list(:bid, 10)
+
+    get '/api/bids?page=2&per_page=3', nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json.length).to eq(3)
   end
 
   it 'should get a single bid (nested)' do

--- a/spec/requests/spree/message_spec.rb
+++ b/spec/requests/spree/message_spec.rb
@@ -8,7 +8,7 @@ describe 'Messages API' do
     user
   end
 
-  it 'must require an api key' do
+  it 'should require an api key' do
     message = FactoryGirl.create(:message)
 
     get "/api/messages/#{message.id}"
@@ -16,7 +16,7 @@ describe 'Messages API' do
     expect(response).to have_http_status(401)
   end
 
-  it 'gets a list of messages' do
+  it 'should get a list of messages' do
     FactoryGirl.create_list(:message, 10)
 
     get '/api/messages', nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
@@ -25,7 +25,16 @@ describe 'Messages API' do
     expect(json.length).to eq(10)
   end
 
-  it 'gets a single message' do
+  it 'should get a page of messages' do
+    FactoryGirl.create_list(:message, 10)
+
+    get '/api/messages?page=2&per_page=3', nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json.length).to eq(3)
+  end
+
+  it 'should get a single message' do
     message = FactoryGirl.create(:message)
 
     get "/api/messages/#{message.id}", nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
@@ -35,7 +44,7 @@ describe 'Messages API' do
     expect(json['subject']).to eq(message.subject)
   end
 
-  it 'sends an update message' do
+  it 'should update a message' do
     message = FactoryGirl.create(:message, subject: 'put subject')
 
     put "/api/messages/#{message.id}", message.to_json, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
@@ -44,7 +53,7 @@ describe 'Messages API' do
     expect(json['subject']).to eq('put subject')
   end
 
-  it 'creates a message' do
+  it 'should create a message' do
     message = FactoryGirl.build(:message, subject: 'posty subject')
 
     post '/api/messages', message.to_json, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
@@ -53,7 +62,7 @@ describe 'Messages API' do
     expect(json['subject']).to eq('posty subject')
   end
 
-  it 'deletes a message' do
+  it 'should deletes a message' do
     message = FactoryGirl.create(:message)
 
     delete "/api/messages/#{message.id}", nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"

--- a/spec/requests/spree/prebid_spec.rb
+++ b/spec/requests/spree/prebid_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+describe 'Prebids API' do
+  let(:current_api_user) do
+    user = Spree.user_class.new(email: 'spree@example.com',
+                                password: 'password')
+    user.generate_spree_api_key!
+    user
+  end
+
+  it 'must require an api key' do
+    prebid = FactoryGirl.create(:prebid)
+
+    get "/api/prebids/#{prebid.id}"
+
+    expect(response).to have_http_status(401)
+  end
+
+  it 'should get a list of prebids' do
+    FactoryGirl.create_list(:prebid, 10)
+
+    get '/api/prebids', nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json.length).to eq(10)
+  end
+
+  it 'should get a page of prebids' do
+    FactoryGirl.create_list(:prebid, 10)
+
+    get '/api/prebids?page=2&per_page=3', nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json.length).to eq(3)
+  end
+
+  it 'should get a single prebid' do
+    prebid = FactoryGirl.create(:prebid, description: 'description get')
+
+    get "/api/prebids/#{prebid.id}", nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json['description']).to eq('description get')
+  end
+
+  it 'should update a prebid' do
+    prebid = FactoryGirl.create(:prebid, description: 'put subject')
+
+    put "/api/prebids/#{prebid.id}", prebid.to_json, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json['description']).to eq('put subject')
+  end
+
+  it 'should create a prebid' do
+    prebid = FactoryGirl.build(:prebid, description: 'posty description')
+
+    post '/api/prebids', prebid.to_json, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+    expect(json['description']).to eq('posty description')
+  end
+
+  it 'should delete a prebid' do
+    prebid = FactoryGirl.create(:prebid)
+
+    delete "/api/prebids/#{prebid.id}", nil, 'X-Spree-Token': "#{current_api_user.spree_api_key}"
+
+    expect(response).to be_success
+  end
+end


### PR DESCRIPTION
Hold for https://github.com/PromoExchange/batman/pull/211

:clipboard: 
1. Run `bundle exec db:bootstrap`
2. Ensure `taxon_id` has been removed from the prebid table
3. Run `bundle exec rspec`
4. There should be no errors

:notebook:
- This PR adds the Prebid API endpoints
- It removes the taxon association on `prebid`
