### PR TITLE
Imprint level up charges, image loads

### DIFF
--- a/app/models/spree/imprint_method.rb
+++ b/app/models/spree/imprint_method.rb
@@ -1,4 +1,7 @@
 class Spree::ImprintMethod < Spree::Base
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+  
   has_and_belongs_to_many :products
 
   validates :name, presence: true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Seed data, load image files
+  config.x.load_images = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Seed data, load image files
+  config.seed.load_images = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Seed data, load image files
+  config.seed.load_images = false
 end

--- a/db/migrate/20150625110508_add_slug_to_imprint_method.rb
+++ b/db/migrate/20150625110508_add_slug_to_imprint_method.rb
@@ -1,0 +1,5 @@
+class AddSlugToImprintMethod < ActiveRecord::Migration
+  def change
+    add_column :spree_imprint_methods, :slug, :string, :unique => true
+  end
+end

--- a/db/migrate/20150625132956_add_position_to_upcharge.rb
+++ b/db/migrate/20150625132956_add_position_to_upcharge.rb
@@ -1,0 +1,5 @@
+class AddPositionToUpcharge < ActiveRecord::Migration
+  def change
+    add_column :spree_upcharges, :position, :integer
+  end
+end

--- a/db/products/norwood.rb
+++ b/db/products/norwood.rb
@@ -72,10 +72,12 @@ CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
       product = Spree::Product.create!(default_attrs.merge(product_attrs))
 
       # Image
-      begin
-        Spree::Image.create(attachment: URI.parse(hashed[:large_image_url]), viewable: product.master)
-      rescue => e
-        ap "Error loading product image [#{product_attrs[:sku]}], #{e}"
+      if Rails.configuration.x.load_images
+        begin
+          Spree::Image.create(attachment: URI.parse(hashed[:large_image_url]), viewable: product.master)
+        rescue => e
+          ap "Error loading product image [#{product_attrs[:sku]}], #{e}"
+        end
       end
 
       price_quantity = get_last_break(hashed, 'quantity', 5)

--- a/db/products/primeline.rb
+++ b/db/products/primeline.rb
@@ -9,7 +9,6 @@ def get_last_break(hashed, root, limit)
   (1..limit).each do |i|
     price_key = "#{root}#{i}".to_sym
     highest = i unless hashed[price_key].to_i == 0
-    # ap "#{price_key}:#{highest}"
   end
   highest
 end
@@ -51,10 +50,12 @@ CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
       product = Spree::Product.create!(default_attrs.merge(product_attrs))
 
       # Image
-      begin
-        Spree::Image.create(attachment: URI.parse(hashed[:image_path]), viewable: product.master)
-      rescue => e
-        ap "Error in #{hashed[:productitem]} image load: #{e}"
+      if Rails.configuration.x.load_images
+        begin
+          Spree::Image.create(attachment: URI.parse(hashed[:image_path]), viewable: product.master)
+        rescue => e
+          ap "Error in #{hashed[:productitem]} image load: #{e}"
+        end
       end
 
       price_quantity = get_last_break(hashed, 'price_break', 5)

--- a/db/products/starline.rb
+++ b/db/products/starline.rb
@@ -41,11 +41,13 @@ CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
       product = Spree::Product.create!(default_attrs.merge(product_attrs))
 
       # Image
-      begin
-        Spree::Image.create(attachment: URI.parse(hashed[:productimageurl]), viewable: product.master)
-      rescue => e
-        ap "Error in #{hashed[:productcode]} image load: #{e}"
-        next
+      if Rails.configuration.x.load_images
+        begin
+          Spree::Image.create(attachment: URI.parse(hashed[:productimageurl]), viewable: product.master)
+        rescue => e
+          ap "Error in #{hashed[:productcode]} image load: #{e}"
+          next
+        end
       end
 
       # Prices

--- a/db/products/vitronic.rb
+++ b/db/products/vitronic.rb
@@ -50,14 +50,16 @@ CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
       product = Spree::Product.create!(default_attrs.merge(product_attrs))
 
       # Image
-      begin
-        image_uri = "http://www.vitronicpromotional.com/image.php?sz=viewitem_lg&itemno=#{hashed[:sku]}"
-        product.images << Spree::Image.create!(
-          attachment: open(URI.parse(image_uri)),
-          viewable: product)
-      rescue => e
-        ap "Warning: Unable to load product image [#{product_attrs[:sku]}], #{e}"
-        image_fail += 1
+      if Rails.configuration.x.load_images
+        begin
+          image_uri = "http://www.vitronicpromotional.com/image.php?sz=viewitem_lg&itemno=#{hashed[:sku]}"
+          product.images << Spree::Image.create!(
+            attachment: open(URI.parse(image_uri)),
+            viewable: product)
+        rescue => e
+          ap "Warning: Unable to load product image [#{product_attrs[:sku]}], #{e}"
+          image_fail += 1
+        end
       end
 
       # Properties

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150624155909) do
+ActiveRecord::Schema.define(version: 20150625132956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 20150624155909) do
     t.string   "name",       null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string   "slug"
   end
 
   create_table "spree_imprint_methods_products", id: false, force: :cascade do |t|
@@ -1164,6 +1165,7 @@ ActiveRecord::Schema.define(version: 20150624155909) do
     t.string  "range"
     t.string  "actual"
     t.string  "price_code"
+    t.integer "position"
   end
 
   create_table "spree_users", force: :cascade do |t|

--- a/db/seed_data/imprint_methods.txt
+++ b/db/seed_data/imprint_methods.txt
@@ -1,12 +1,14 @@
 Deboss
-Digital Label
-Embroidery
-Image bonding
-4 color
-3d 4 color
-Laser engraved
-Pad Print
 Silk Screen
+Pad Print
+Embroider
+Engrave
+Logomatic
+Gemphoto
+Direct Digital Print
+Digital Label
 Transfer
-Vibratec
-Engraved
+Valuemark
+Logomark
+Vinyl
+ColorSplash

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,6 @@ require 'csv'
 # Product loader
 require './lib/product_loader'
 
-#  Seeds.rb
 Spree::Core::Engine.load_seed if defined?(Spree::Core)
 Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
 
@@ -147,5 +146,12 @@ end
 ).each { |supplier| ProductLoader.load('products', supplier) }
 
 %w(
+  gemline
+  crown
+  fields
+  high_caliber
+  logomark
+  primeline
+  starline
   vitronic
 ).each { |supplier| ProductLoader.load('upcharges', supplier) }

--- a/db/upcharge_data/crown_imprint.csv
+++ b/db/upcharge_data/crown_imprint.csv
@@ -1,0 +1,7 @@
+imprint_slug,charge_type,range1,range2,range3,range4,range5,price1,price2,price3,price4,price5
+silk-screen,SETUP,0,0,0,0,0,55,0,0,0,0
+engrave,SETUP,0,0,0,0,0,55,0,0,0,0
+deboss,SETUP,0,0,0,0,0,70,0,0,0,0
+digital-label,SETUP,0,0,0,0,0,55,0,0,0,0
+direct-digital-print,SETUP,0,0,0,0,0,95,0,0,0,0
+direct-digital-print,RUN,1+,0,0,0,0,0.99,0,0,0,0

--- a/db/upcharge_data/fields_imprint.csv
+++ b/db/upcharge_data/fields_imprint.csv
@@ -1,0 +1,3 @@
+imprint_slug,charge_type,range1,range2,range3,range4,range5,price1,price2,price3,price4,price5
+silk-screen,SETUP,0,0,0,0,0,50,0,0,0,0
+silk-screen,RUN,1+,0,0,0,0,0.40,0,0,0,0

--- a/db/upcharge_data/gemline_imprint.csv
+++ b/db/upcharge_data/gemline_imprint.csv
@@ -1,0 +1,7 @@
+imprint_slug,charge_type,range1,range2,range3,range4,range5,price1,price2,price3,price4,price5
+silk-screen,SETUP,0,0,0,0,0,44,0,0,0,0
+silk-screen,RUN,(6..99),(100..299),(300..399),1000+,0,0.79,0.59,0.47,0.36,0
+embroider,RUN,(6..99),(100..299),300+,0,0,2.24,2.04,1.83,0,0
+deboss,SETUP,0,0,0,0,0,56,0,0,0,0
+logomatic,SETUP,0,0,0,0,0,44,0,0,0,0
+gemphoto,RUN,(1..99),(100..299),(300.399),1000+,0,2.24,2.04,1.83,1.64,0

--- a/db/upcharge_data/gemline_supplier.csv
+++ b/db/upcharge_data/gemline_supplier.csv
@@ -1,0 +1,2 @@
+pms_color_match,55
+ink_change,35

--- a/db/upcharge_data/high_caliber_imprint.csv
+++ b/db/upcharge_data/high_caliber_imprint.csv
@@ -1,0 +1,5 @@
+imprint_slug,charge_type,range1,range2,range3,range4,range5,price1,price2,price3,price4,price5
+silk-screen,SETUP,0,0,0,0,0,50,0,0,0,0
+silk-screen,RUN,1+,0,0,0,0,0.30,0,0,0,0
+direct-digital-print,SETUP,0,0,0,0,0,50,0,0,0,0
+direct-digital-print,RUN,1+,0,0,0,0,0.40,0,0,0,0

--- a/db/upcharge_data/logomark_imprint.csv
+++ b/db/upcharge_data/logomark_imprint.csv
@@ -1,0 +1,15 @@
+imprint_slug,charge_type,range1,range2,range3,range4,range5,price1,price2,price3,price4,price5
+engrave,SETUP,0,0,0,0,0,45,0,0,0,0
+engrave,RUN,1+,0,0,0,0,0.32,0,0,0,0
+valuemark,SETUP,0,0,0,0,0,45,0,0,0,0
+valuemark,RUN,1+,0,0,0,0,0.20,0,0,0,0
+logomark,SETUP,0,0,0,0,0,50,0,0,0,0
+logomark,RUN,1+,0,0,0,0,0.32,0,0,0,0
+vinyl,SETUP,0,0,0,0,0,45,0,0,0,0
+vinyl,RUN,1+,0,0,0,0,0.32,0,0,0,0
+transfer,SETUP,0,0,0,0,0,45,0,0,0,0
+transfer,RUN,1+,0,0,0,0,1,0,0,0,0
+colorsplash,SETUP,0,0,0,0,0,45,0,0,0,0
+colorsplash,RUN,1+,0,0,0,0,0.32,0,0,0,0
+deboss,SETUP,0,0,0,0,0,80,0,0,0,0
+deboss,RUN,1+,0,0,0,0,0.32,0,0,0,0

--- a/db/upcharge_data/primeline_imprint.csv
+++ b/db/upcharge_data/primeline_imprint.csv
@@ -1,0 +1,8 @@
+imprint_slug,charge_type,range1,range2,range3,range4,range5,price1,price2,price3,price4,price5
+deboss,SETUP,0,0,0,0,0,64,0,0,0,0
+deboss,RUN,1+,0,0,0,0,1,0,0,0,0
+digital-label,SETUP,0,0,0,0,0,48,0,0,0,0
+silk-screen,SETUP,0,0,0,0,0,48,0,0,0,0
+silk-screen,RUN,1+,0,0,0,0,0.52,0,0,0,0
+transfer,SETUP,0,0,0,0,0,48,0,0,0,0
+transfer,RUN,1+,0,0,0,0,0.52,0,0,0,0

--- a/db/upcharge_data/starline_imprint.csv
+++ b/db/upcharge_data/starline_imprint.csv
@@ -1,0 +1,9 @@
+imprint_slug,charge_type,range1,range2,range3,range4,range5,price1,price2,price3,price4,price5,price_code
+silk-screen,SETUP,0,0,0,0,0,55,0,0,0,0,G
+silk-screen,RUN,1+,0,0,0,0,1,0,0,0,0,G
+direct-digital-print,SETUP,0,0,0,0,0,55,0,0,0,0,G
+direct-digital-print,RUN,1+,0,0,0,0,0.5,0,0,0,0,G
+embroider,SETUP,0,0,0,0,0,80,0,0,0,0,G
+embroider,RUN,(6..23),(24..99),(100.299),(300..399),400+,5.39,3.69,2.99,2.59,2.59,G
+deboss,SETUP,0,0,0,0,0,70,0,0,0,0,G
+deboss,RUN,1+,0,0,0,0,1.20,0,0,0,0,G

--- a/db/upcharge_data/starline_supplier.csv
+++ b/db/upcharge_data/starline_supplier.csv
@@ -1,0 +1,3 @@
+pms_color_match,35
+ink_change,20
+no_under_over,25

--- a/db/upcharges/crown.rb
+++ b/db/upcharges/crown.rb
@@ -1,0 +1,50 @@
+require 'csv'
+
+# Imprint Level
+puts 'Loading Crown Imprint level upcharges'
+
+# TODO: DRY This up, place in lib method
+
+setup_type = Spree::UpchargeType.where(name: 'setup').first.id
+run_type = Spree::UpchargeType.where(name: 'run').first.id
+
+file_name = File.join(Rails.root, 'db/upcharge_data/crown_imprint.csv')
+imprint_upcharge_count = 0
+
+CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
+  hashed = row.to_hash
+
+  is_setup = (hashed[:charge_type] == 'SETUP')
+
+  imprint = Spree::ImprintMethod.where(slug: hashed[:imprint_slug]).first
+
+  next if imprint.nil?
+
+  attrs = {
+    upcharge_type_id: (is_setup ? setup_type : run_type),
+    related_type: 'Spree::ImprintMethod',
+  }
+  attrs[:related_id] = imprint.id
+
+  if is_setup
+    attrs[:value] = hashed[:price1]
+    Spree::Upcharge.create(attrs)
+    imprint_upcharge_count += 1
+  else
+    (1..5).each do |i|
+      range_key = "range#{i}".to_sym
+      price_key = "price#{i}".to_sym
+
+      next if hashed[range_key] == '0'
+
+      attrs[:range] = hashed[range_key]
+      attrs[:value] = hashed[price_key]
+      attrs[:position] = i
+
+      Spree::Upcharge.create(attrs)
+      imprint_upcharge_count += 1
+    end
+  end
+end
+
+puts "Loaded #{imprint_upcharge_count} imprint upcharges"

--- a/db/upcharges/fields.rb
+++ b/db/upcharges/fields.rb
@@ -1,0 +1,50 @@
+require 'csv'
+
+# Imprint Level
+puts 'Loading Fields Imprint level upcharges'
+
+# TODO: DRY This up, place in lib method
+
+setup_type = Spree::UpchargeType.where(name: 'setup').first.id
+run_type = Spree::UpchargeType.where(name: 'run').first.id
+
+file_name = File.join(Rails.root, 'db/upcharge_data/fields_imprint.csv')
+imprint_upcharge_count = 0
+
+CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
+  hashed = row.to_hash
+
+  is_setup = (hashed[:charge_type] == 'SETUP')
+
+  imprint = Spree::ImprintMethod.where(slug: hashed[:imprint_slug]).first
+
+  next if imprint.nil?
+  
+  attrs = {
+    upcharge_type_id: (is_setup ? setup_type : run_type),
+    related_type: 'Spree::ImprintMethod',
+  }
+  attrs[:related_id] = imprint.id
+
+  if is_setup
+    attrs[:value] = hashed[:price1]
+    Spree::Upcharge.create(attrs)
+    imprint_upcharge_count += 1
+  else
+    (1..5).each do |i|
+      range_key = "range#{i}".to_sym
+      price_key = "price#{i}".to_sym
+
+      next if hashed[range_key] == '0'
+
+      attrs[:range] = hashed[range_key]
+      attrs[:value] = hashed[price_key]
+      attrs[:position] = i
+
+      Spree::Upcharge.create(attrs)
+      imprint_upcharge_count += 1
+    end
+  end
+end
+
+puts "Loaded #{imprint_upcharge_count} imprint upcharges"

--- a/db/upcharges/gemline.rb
+++ b/db/upcharges/gemline.rb
@@ -1,0 +1,67 @@
+require 'csv'
+
+# Imprint Level
+puts 'Loading Gemline Imprint level upcharges'
+
+setup_type = Spree::UpchargeType.where(name: 'setup').first.id
+run_type = Spree::UpchargeType.where(name: 'run').first.id
+
+file_name = File.join(Rails.root, 'db/upcharge_data/gemline_imprint.csv')
+imprint_upcharge_count = 0
+
+CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
+  hashed = row.to_hash
+
+  is_setup = (hashed[:charge_type] == 'SETUP')
+
+  imprint = Spree::ImprintMethod.where(slug: hashed[:imprint_slug]).first
+
+  next if imprint.nil?
+  
+  attrs = {
+    upcharge_type_id: (is_setup ? setup_type : run_type),
+    related_type: 'Spree::ImprintMethod',
+  }
+  attrs[:related_id] = imprint.id
+
+  if is_setup
+    attrs[:value] = hashed[:price1]
+    Spree::Upcharge.create(attrs)
+    imprint_upcharge_count += 1
+  else
+    (1..5).each do |i|
+      range_key = "range#{i}".to_sym
+      price_key = "price#{i}".to_sym
+
+      next if hashed[range_key] == '0'
+
+      attrs[:range] = hashed[range_key]
+      attrs[:value] = hashed[price_key]
+      attrs[:position] = i
+
+      Spree::Upcharge.create(attrs)
+      imprint_upcharge_count += 1
+    end
+  end
+end
+
+puts "Loaded #{imprint_upcharge_count} imprint upcharges"
+
+# Supplier level
+puts 'Loading Gemline supplier upcharges'
+
+supplier = Spree::Supplier.find_by_name('Gemline')
+
+file_name = File.join(Rails.root, 'db/upcharge_data/gemline_supplier.csv')
+supplier_upcharge_count = 0
+# Supplier Level
+File.open(file_name, 'r').each_line do |line|
+  charge_values = line.strip.split(',')
+  upcharge_type_id = Spree::UpchargeType.find_by_name(charge_values[0]).id
+  Spree::Upcharge.create(
+    upcharge_type_id: upcharge_type_id,
+    related_type: 'Spree::Supplier',
+    related_id: supplier.id,
+    value: charge_values[1])
+  supplier_upcharge_count += 1
+end

--- a/db/upcharges/high_caliber.rb
+++ b/db/upcharges/high_caliber.rb
@@ -1,0 +1,48 @@
+require 'csv'
+
+# Imprint Level
+puts 'Loading High Caliber Imprint level upcharges'
+
+setup_type = Spree::UpchargeType.where(name: 'setup').first.id
+run_type = Spree::UpchargeType.where(name: 'run').first.id
+
+file_name = File.join(Rails.root, 'db/upcharge_data/high_caliber_imprint.csv')
+imprint_upcharge_count = 0
+
+CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
+  hashed = row.to_hash
+
+  is_setup = (hashed[:charge_type] == 'SETUP')
+
+  imprint = Spree::ImprintMethod.where(slug: hashed[:imprint_slug]).first
+
+  next if imprint.nil?
+  
+  attrs = {
+    upcharge_type_id: (is_setup ? setup_type : run_type),
+    related_type: 'Spree::ImprintMethod',
+  }
+  attrs[:related_id] = imprint.id
+
+  if is_setup
+    attrs[:value] = hashed[:price1]
+    Spree::Upcharge.create(attrs)
+    imprint_upcharge_count += 1
+  else
+    (1..5).each do |i|
+      range_key = "range#{i}".to_sym
+      price_key = "price#{i}".to_sym
+
+      next if hashed[range_key] == '0'
+
+      attrs[:range] = hashed[range_key]
+      attrs[:value] = hashed[price_key]
+      attrs[:position] = i
+
+      Spree::Upcharge.create(attrs)
+      imprint_upcharge_count += 1
+    end
+  end
+end
+
+puts "Loaded #{imprint_upcharge_count} imprint upcharges"

--- a/db/upcharges/logomark.rb
+++ b/db/upcharges/logomark.rb
@@ -1,0 +1,48 @@
+require 'csv'
+
+# Imprint Level
+puts 'Loading Logomark Imprint level upcharges'
+
+setup_type = Spree::UpchargeType.where(name: 'setup').first.id
+run_type = Spree::UpchargeType.where(name: 'run').first.id
+
+file_name = File.join(Rails.root, 'db/upcharge_data/logomark_imprint.csv')
+imprint_upcharge_count = 0
+
+CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
+  hashed = row.to_hash
+
+  is_setup = (hashed[:charge_type] == 'SETUP')
+
+  imprint = Spree::ImprintMethod.where(slug: hashed[:imprint_slug]).first
+
+  next if imprint.nil?
+  
+  attrs = {
+    upcharge_type_id: (is_setup ? setup_type : run_type),
+    related_type: 'Spree::ImprintMethod',
+  }
+  attrs[:related_id] = imprint.id
+
+  if is_setup
+    attrs[:value] = hashed[:price1]
+    Spree::Upcharge.create(attrs)
+    imprint_upcharge_count += 1
+  else
+    (1..5).each do |i|
+      range_key = "range#{i}".to_sym
+      price_key = "price#{i}".to_sym
+
+      next if hashed[range_key] == '0'
+
+      attrs[:range] = hashed[range_key]
+      attrs[:value] = hashed[price_key]
+      attrs[:position] = i
+
+      Spree::Upcharge.create(attrs)
+      imprint_upcharge_count += 1
+    end
+  end
+end
+
+puts "Loaded #{imprint_upcharge_count} imprint upcharges"

--- a/db/upcharges/primeline.rb
+++ b/db/upcharges/primeline.rb
@@ -1,0 +1,48 @@
+require 'csv'
+
+# Imprint Level
+puts 'Loading Primeline Imprint level upcharges'
+
+setup_type = Spree::UpchargeType.where(name: 'setup').first.id
+run_type = Spree::UpchargeType.where(name: 'run').first.id
+
+file_name = File.join(Rails.root, 'db/upcharge_data/primeline_imprint.csv')
+imprint_upcharge_count = 0
+
+CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
+  hashed = row.to_hash
+
+  is_setup = (hashed[:charge_type] == 'SETUP')
+
+  imprint = Spree::ImprintMethod.where(slug: hashed[:imprint_slug]).first
+
+  next if imprint.nil?
+  
+  attrs = {
+    upcharge_type_id: (is_setup ? setup_type : run_type),
+    related_type: 'Spree::ImprintMethod',
+  }
+  attrs[:related_id] = imprint.id
+
+  if is_setup
+    attrs[:value] = hashed[:price1]
+    Spree::Upcharge.create(attrs)
+    imprint_upcharge_count += 1
+  else
+    (1..5).each do |i|
+      range_key = "range#{i}".to_sym
+      price_key = "price#{i}".to_sym
+
+      next if hashed[range_key] == '0'
+
+      attrs[:range] = hashed[range_key]
+      attrs[:value] = hashed[price_key]
+      attrs[:position] = i
+
+      Spree::Upcharge.create(attrs)
+      imprint_upcharge_count += 1
+    end
+  end
+end
+
+puts "Loaded #{imprint_upcharge_count} imprint upcharges"

--- a/db/upcharges/starline.rb
+++ b/db/upcharges/starline.rb
@@ -1,0 +1,67 @@
+require 'csv'
+
+# Imprint level
+setup_type = Spree::UpchargeType.where(name: 'setup').first.id
+run_type = Spree::UpchargeType.where(name: 'run').first.id
+
+file_name = File.join(Rails.root, 'db/upcharge_data/starline_imprint.csv')
+imprint_upcharge_count = 0
+CSV.foreach(file_name, headers: true, header_converters: :symbol) do |row|
+  hashed = row.to_hash
+
+  is_setup = (hashed[:charge_type] == 'SETUP')
+
+  imprint = Spree::ImprintMethod.where(slug: hashed[:imprint_slug]).first
+
+  next if imprint.nil?
+  
+  attrs = {
+    upcharge_type_id: (is_setup ? setup_type : run_type),
+    related_type: 'Spree::ImprintMethod',
+  }
+  attrs[:related_id] = imprint.id
+  attrs[:price_code] = hashed[:price_code]
+
+  if is_setup
+    attrs[:value] = hashed[:price1]
+    Spree::Upcharge.create(attrs)
+    imprint_upcharge_count += 1
+  else
+    (1..5).each do |i|
+      range_key = "range#{i}".to_sym
+      price_key = "price#{i}".to_sym
+
+      next if hashed[range_key] == '0'
+
+      attrs[:range] = hashed[range_key]
+      attrs[:value] = hashed[price_key]
+      attrs[:position] = i
+
+      Spree::Upcharge.create(attrs)
+      imprint_upcharge_count += 1
+    end
+  end
+end
+puts "Loaded #{imprint_upcharge_count} imprint upcharges"
+
+# Supplier level
+puts 'Loading Starline supplier upcharges'
+
+supplier = Spree::Supplier.find_by_name('Starline')
+
+file_name = File.join(Rails.root, 'db/upcharge_data/starline_supplier.csv')
+
+supplier_upcharge_count = 0
+
+File.open(file_name, 'r').each_line do |line|
+  charge_values = line.strip.split(',')
+  upcharge_type_id = Spree::UpchargeType.find_by_name(charge_values[0]).id
+  Spree::Upcharge.create(
+    upcharge_type_id: upcharge_type_id,
+    related_type: 'Spree::Supplier',
+    related_id: supplier.id,
+    value: charge_values[1])
+  supplier_upcharge_count += 1
+end
+
+puts "Loaded #{supplier_upcharge_count} supplier upcharges"


### PR DESCRIPTION
:clipboard: 
- Run `bundle exec db:drop db:create db:migrate'
- Run `bundle exec db:seed`
- Image load is now configurable `config.x.load_images` in `config/environments/[development|production|test].rb`. Default in development is to not load images.
- Ensure no products have images
- Set `config.x.load_images` = true and run product load again.
- Ensure products have images
- Ensure `Spree::Upcharge` is populated with all the factories below (all but leeds, norwood and sweda)

:notebook:
- Load Gemline supplier and imprint, starline supplier
- Add Upcharge position to upcharges (for range
- Load Starline imprint level up charges
- Load Primeline imprint upcharges
- High Caliber Imprint up charges
- Crown imprint level upcharges
- Fields imprint upcharges
- Logomark imprint upcharges
- Image load configurable, Load Norwood Images
