### PR TITLE
Dashboard, Auction view, Dashboard, Fixes

### DIFF
--- a/app/controllers/spree/auctions_controller.rb
+++ b/app/controllers/spree/auctions_controller.rb
@@ -37,6 +37,8 @@ class Spree::AuctionsController < Spree::StoreController
       "Billing: #{@auction.buyer.billing_address}",
       @auction.buyer.billing_address.id] unless @auction.buyer.billing_address.nil?
 
+      @product_properties = @auction.product.product_properties.accessible_by(current_ability, :read)
+
     # TODO: pluck it
     @pms_colors = Spree::PmsColorsSupplier
       .select(

--- a/app/controllers/spree/dashboards_controller.rb
+++ b/app/controllers/spree/dashboards_controller.rb
@@ -8,11 +8,19 @@ class Spree::DashboardsController < Spree::StoreController
   def index
     @live_auctions = Spree::Auction.open.where(buyer: current_spree_user)
       .page(params[:page])
-      .per(params[:per_page] || Spree::Config[:products_per_page])
+      .per(params[:per_page] || Spree::Config[:orders_per_page])
+
     @waiting_auctions = Spree::Auction.waiting.where(buyer: current_spree_user)
       .page(params[:page])
-      .per(params[:per_page] || Spree::Config[:products_per_page])
+      .per(params[:per_page] || Spree::Config[:orders_per_page])
+
     @favorites = Spree::Favorite.where(buyer: current_spree_user)
       .includes(:product)
+  end
+
+  private
+
+  def dashboard_params
+    params.permit(:page, :per_page)
   end
 end

--- a/app/models/spree/auction.rb
+++ b/app/models/spree/auction.rb
@@ -32,11 +32,7 @@ class Spree::Auction < Spree::Base
   end
 
   def image
-    image_url = 'noimage/mini.png'
-    unless product.images.empty?
-      image_url = product.images.first.attachment.url('mini')
-    end
-    image_url
+    product.images.empty? ? 'noimage/mini.png' : product.images.first.attachment.url('mini')
   end
 
   def lowest_bid

--- a/app/models/spree/favorite.rb
+++ b/app/models/spree/favorite.rb
@@ -5,6 +5,10 @@ class Spree::Favorite < Spree::Base
   validates :buyer_id, presence: true
   validates :product_id, presence: true
 
+  def image
+    product.images.empty? ? 'noimage/small_image.png' : product.images.first.attachment.url('small')
+  end
+
   def self.user_favorites
     Spree::Auctions.where(buyer_id: current_spree_user.id)
   end

--- a/app/views/spree/auctions/_properties.html.erb
+++ b/app/views/spree/auctions/_properties.html.erb
@@ -1,0 +1,15 @@
+<% unless @product_properties.empty? %>
+  <h3 class="product-section-title"><%= Spree.t('properties')%></h3>
+  <table id="product-properties" class="table table-striped" data-hook>
+    <tbody>
+      <% @product_properties.each do |product_property| %>
+        <% css_class = cycle('even', 'odd', :name => 'properties') %>
+        <tr class="<%= css_class %>">
+          <td><strong><%= product_property.property.presentation %></strong></td>
+          <td><%= product_property.value %></td>
+        </tr>
+      <% end %>
+      <% reset_cycle('properties') %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/spree/auctions/new.html.erb
+++ b/app/views/spree/auctions/new.html.erb
@@ -7,6 +7,7 @@
     <% url = spree.product_url(@auction.product) %>
     <%= link_to large_image(@auction.product, itemprop: "image"), url, itemprop: 'url' %><br/>
     <p><%=@auction.product.description%></p>
+    <%= render partial: 'properties' %>
   </div>
   <div class="col-md-6 well">
     <h2><%= @auction.product.name %></h2>

--- a/app/views/spree/dashboards/_auctions.html.erb
+++ b/app/views/spree/dashboards/_auctions.html.erb
@@ -6,11 +6,10 @@
   <li class="active"><a href="#live-auction" role="tab" data-toggle="tab"><%=Spree.t(:auctions)%></a></li>
   <li><a href="#awaiting-selection" role="tab" data-toggle="tab"><%=Spree.t(:awaiting_selection)%></a></li>
 </ul>
-<!-- Tab panes -->
+
 <div class="tab-content">
   <div class="tab-pane active" id="live-auction">
     <% if @live_auctions.any? %>
-      <%= paginate @live_auctions %>
       <table data-id="<%=spree_current_user.spree_api_key%>" class="table table-striped" id="auction-table">
         <thead>
           <tr>

--- a/app/views/spree/dashboards/_favorite_items.html.erb
+++ b/app/views/spree/dashboards/_favorite_items.html.erb
@@ -3,15 +3,29 @@
 <% end %>
 
 <div class="row">
-<% @favorites.each do |favorite| %>
-    <div class="col-md-4">
-      <div id="product-cell">
-        <div class="pull-left">
-          <%= link_to small_image(favorite.product, itemprop: "image")%>
+<% if @favorites.any? %>
+  <% @favorites.each do |favorite| %>
+    <div class="col-md-3 col-sm-6 product-list-item">
+      <div class="panel panel-default">
+        <div class="panel-body text-center product-body">
+          <%= image_tag favorite.image, { itemprop: "image", alt: favorite.product.name } %>
+          <p>
+          <%= link_to truncate(favorite.product.name, length: 50),
+                product_url(favorite.product),
+                class: 'info',
+                itemprop: "name",
+                title: favorite.product.name %>
+              </p>
         </div>
-        <%= favorite.product.name %><br/>
-        <%= link_to Spree.t(:auction), products_url , class: 'btn btn-default' %>
+        <div class="panel-footer text-center">
+          <%= link_to Spree.t(:start_auction), product_url(favorite.product) , class: 'btn btn-default' %>
+        </div>
       </div>
     </div>
+  <% end %>
+<% else %>
+  <div class="alert alert-info no-objects-found">
+    <%= Spree.t(:no_resource_found, resource: Spree.t(:favorites)).html_safe %>.
+  </div>
 <% end %>
 </div>

--- a/app/views/spree/product/_index_product.erb
+++ b/app/views/spree/product/_index_product.erb
@@ -1,0 +1,2 @@
+<%= link_to small_image(product, itemprop: 'image'), main_app.new_auction_path(product_id: product.id), itemprop: 'url' %><br/>
+<%= link_to truncate(product.name, length: 50), main_app.new_auction_path(product_id: product.id), class: 'info', itemprop: "name", title: product.name %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,5 @@
 require 'csv'
 
-# Product loader
-require './lib/product_loader'
-
 Spree::Core::Engine.load_seed if defined?(Spree::Core)
 Spree::Auth::Engine.load_seed if defined?(Spree::Auth)
 
@@ -68,6 +65,19 @@ Spree::Role.where(name: 'buyer').first_or_create
 Spree::Role.where(name: 'seller').first_or_create
 Spree::Role.where(name: 'supplier').first_or_create
 
+country = Spree::Country.where( iso3: 'USA' ).first
+state = Spree::State.where( name: 'New York' ).first
+address = Spree::Address.create(
+  firstname: 'Donald',
+  lastname: 'Duck',
+  address1: '123 PromoExchange Road',
+  city: 'Tarrytown',
+  zipcode: '10591',
+  state_id: state.id,
+  country_id: country.id,
+  phone: '555-555-5555'
+  )
+
 puts 'Users'
 [
   ['michael.goldstein@thepromoexchange.com', 'admin'],
@@ -85,6 +95,9 @@ puts 'Users'
                             password: 'spree123',
                             password_confirmation: 'spree123')
   user.spree_roles << Spree::Role.find_by_name(r[1])
+  user.generate_spree_api_key!
+  user.bill_address = address
+  user.ship_address = address
   user.save!
 end
 

--- a/lib/tasks/productload.rake
+++ b/lib/tasks/productload.rake
@@ -39,7 +39,7 @@ namespace :product do
 
     desc 'Norwood Load'
     task norwood: :environment do
-      load_files('norwood')
+      ProductLoader.load('products', 'norwood')
     end
 
     desc 'Primeline Load'

--- a/vendor/assets/javascripts/spree/frontend/dashboard/auction.js
+++ b/vendor/assets/javascripts/spree/frontend/dashboard/auction.js
@@ -1,0 +1,43 @@
+$(function(){
+  $('#auction-tab').click(function(e) {
+      $("#live-auction-table > tbody").html("<tr><td class='text-center' colspan='4'><i class='fa fa-spinner fa-pulse fa-3x'></i></td></tr>");;
+      var key = $("#live-auction-table").attr("data-id");
+      $.ajax({
+        type: 'GET',
+        data:{
+          format: 'json'
+        },
+        url: '/api/auctions',
+        headers:{
+          'X-Spree-Token': key
+        },
+        success: function(data){
+          var trHTML = '';
+          if( data.length > 0 ){
+            $.each(data, function(i,item){
+              var crate = new Date(item.created_at)
+              trHTML += "<tr><td><input type='checkbox'></td>";
+              trHTML += "<td>"+crate.toLocaleString()+"</td>";
+              trHTML += "<td>"+item.subject+"</td>";
+              trHTML += "<td><i class='fa fa-trash'></i></td>";
+
+              trHTML += "<tr><td>"image_tag auction.image, { itemprop: "image", alt: auction.product.name } %><p><%= auction.product.name %></p></td>
+              <td><%= auction.lowest_bid.seller.email if auction.lowest_bid %></td>
+              <td><%= auction.quantity %></td>
+              <td><%= local_time(auction.started, '%m/%d/%Y') if auction.started %></td>
+              <td><%= local_time(auction.ended, '%m/%d/%Y') if auction.ended %></td>
+              <td><ul>
+                <li><%= link_to Spree.t(:cancel), main_app.auction_path(auction), method: :delete, :data => {:confirm => 'Are you sure?'}%></li>
+              </ul></td>
+
+            });
+          }else{
+            trHTML += "<tr><td class='text-center' colspan='4'>No messages found!</td></tr>";
+          }
+          $("#message-table > tbody").html(trHTML);
+        }
+      });
+      $(this).tab('show');
+      return false;
+  });
+});


### PR DESCRIPTION
:clipboard: 
- Run `bundle exec db:drop db:create db:migrate`
- Run `bundle exec db:seed`
- Run `bundle exec product:load:vitronic product:load:norwood`
- Ensure both loads succeed
- Run `bundle exec rails s`
- Ensure product properties are displayed on the auction view
- Ensure you can create auctions using a default address (use your personal email account to login)
- View product details and favorite some products
- Ensure favorites panel is viewable in the dashboard and operational

:notebook: 
- Fix missing file load for norwood
- Seed addresses and API key
- Display product properties on new auction view
- Favorites dashboard
