### PR TITLE
Bid price hotfix

### DIFF
--- a/app/controllers/spree/api/bids_controller.rb
+++ b/app/controllers/spree/api/bids_controller.rb
@@ -62,15 +62,18 @@ class Spree::Api::BidsController < Spree::Api::BaseController
       seller_id: json['seller_id']
     )
     @bid.save
-
+    price = json['per_unit_bid'].to_s
+    quantity = @bid.auction.quantity
     unless json['per_unit_bid'].nil?
-      Spree::LineItem.create(
+      li = Spree::LineItem.create(
         currency: 'USD',
         order_id: @bid.order.id,
-        quantity: @bid.auction.quantity,
-        price: json['per_unit_bid'],
-        variant_id: @bid.auction.product.master.id
+        quantity: quantity,
+        variant: @bid.auction.product.master
       )
+
+      li.price = price
+      li.save
 
       order_updater = Spree::OrderUpdater.new(@bid.order)
       order_updater.update

--- a/vendor/assets/javascripts/spree/frontend/dashboard/bid_modal.js
+++ b/vendor/assets/javascripts/spree/frontend/dashboard/bid_modal.js
@@ -79,7 +79,6 @@ $(function () {
     $('.modal-body #per-unit-price-shown').val(+per_unit_price_shown.toFixed(2));
     $('.modal-body #total-price-shown').val(+total_price_shown.toFixed(2));
     var s = flash_fields.join(',');
-    // $(s).delay(100).fadeOut().fadeIn('200');
     $(s).stop().css("background-color", "#FFFF9C")
       .animate({ backgroundColor: "#FFFFFF"}, 500);
   }


### PR DESCRIPTION
:clipboard: 
- Run `bundle exec db:drop db:create db:migrate`
- Run `bundle exec db:seed`
- Run `bundle exec product:load:vitronic`
- Run `bundle exec rails s`
- Sign in as buyer, create 3 auctions
- Go to `My Account`
- Cancel an auction
- From a console ensure auction was soft deleted (status: 'cancelled')
- Sign in as seller
- Go to 'My Account'
- Ensure auction displays 3 low bid (no bids)
- Press bid and ensure panel is populated
- Enter bid data and press bid
- Ensure Lowest 3 bids includes your bid

:notebook: 
- The old bid calculation was incorrect causing all prices to be the volume price only. The actual bid was ignored.
