### PR TITLE
Remove extra $ from accept bid dialog

### DIFF
--- a/vendor/assets/javascripts/spree/frontend/auction/show_auction.js
+++ b/vendor/assets/javascripts/spree/frontend/auction/show_auction.js
@@ -2,7 +2,7 @@ $(function() {
   $('.accept-link').click(function(e) {
     e.preventDefault();
     var bid = $(this).data('bid');
-    var accept = confirm("Are you sure you want to accept this bid of $" + accounting.formatMoney(parseFloat(bid)));
+    var accept = confirm("Are you sure you want to accept this bid of " + accounting.formatMoney(parseFloat(bid)));
     var key = $('#show-auction').attr('data-key');
     var bid_id = $(this).data('id');
     var url = '/api/bids/' + bid_id + '/accept';


### PR DESCRIPTION
:clipboard: 
- Sign in as buyer
- Create auction
- Click accept bid link in auction detail
- Ensure dialog only has a single $ prefixing the bid amount.
