### PR TITLE
Change buyer payment page error style, centralized payment style

### DIFF
--- a/vendor/assets/stylesheets/spree/frontend/dashboard/payment_modal.scss
+++ b/vendor/assets/stylesheets/spree/frontend/dashboard/payment_modal.scss
@@ -1,7 +1,0 @@
-#pay-invoice {
-  .payment-errors {
-    font-weight: bold;
-    font-size: 1.2em;
-    color: red;
-  }
-}

--- a/vendor/assets/stylesheets/spree/frontend/main.scss
+++ b/vendor/assets/stylesheets/spree/frontend/main.scss
@@ -60,4 +60,3 @@
 .pct::after {
   content: '%';
 }
-    

--- a/vendor/assets/stylesheets/spree/frontend/shared/payment.scss
+++ b/vendor/assets/stylesheets/spree/frontend/shared/payment.scss
@@ -1,0 +1,5 @@
+.payment-errors {
+  font-weight: bold;
+  font-size: 1.2em;
+  color: red;
+}


### PR DESCRIPTION
:clipboard: 
- Run `bundle exec rails s`
- Sign in as buyer
- Create auction
- Accept bid
- On payment panel enter invalid data
- Ensure error messages are larger font and in red
