### PR TITLE
Should only receive this email after 24hrs of unresponsiveness

### DIFF
--- a/app/models/spree/bid.rb
+++ b/app/models/spree/bid.rb
@@ -57,7 +57,7 @@ class Spree::Bid < Spree::Base
       email_address: seller.email
     )
     Resque.enqueue_at(
-      Time.zone.now + 24.hours,
+      Time.zone.tomorrow.midnight,
       ConfirmOrderTimeExpire,
       auction_id: auction.id,
       email_address: seller.email


### PR DESCRIPTION
- Once buyer accept the bid for non-prefer seller.
- if seller not confirm for next 24 hours then a email is send to selller. 
