### PR TITLE
Display payment to 2 decimal places

### DIFF
--- a/app/views/spree/auctions/auction_payment.html.erb
+++ b/app/views/spree/auctions/auction_payment.html.erb
@@ -52,7 +52,7 @@
   </div>
 
   <div class="col-md-6">
-    <h2>Payment: $<%= @bid.bid %> </h2>
+    <h2>Payment: $<%= number_with_precision(@bid.bid,precision: 2) %> </h2>
     <form action="/accept" id="buyer-form" method="POST" class="form">
       <%= hidden_field_tag id='bid-id', @bid.id %>
       <span class="payment-errors"></span>


### PR DESCRIPTION
:clipboard: 
- Sign in as buyer
- Create auction (Try to get 0 in the penny column of the bid, i.e. 299.50)
- If you cannot, adjust the `Spree::LineItem` to .00
- Accept the order
- Ensure the payment pay displays the bid to 2 decimal places
