### PR TITLE
Send claim payment email every 24hrs and display claim payment

### DIFF
--- a/app/helpers/spree/api/api_helpers_decorator.rb
+++ b/app/helpers/spree/api/api_helpers_decorator.rb
@@ -45,6 +45,7 @@ Spree::Api::ApiHelpers.module_eval do
       :started,
       :ended,
       :state,
+      :payment_claimed,
       :reference,
       :product_unit_price,
       :payment_method

--- a/app/jobs/claim_payment.rb
+++ b/app/jobs/claim_payment.rb
@@ -1,0 +1,13 @@
+module ClaimPayment
+  @queue = :claim_payment
+
+  def self.perform(params)
+    @auction = Spree::Auction.find(params['auction_id'])
+    SellerMailer.claim_payment(@auction).deliver
+    Resque.enqueue_at(
+      EmailHelpers.email_delay(Time.zone.now + 1.days),
+      ClaimPayment,
+      auction_id: id
+    )
+  end
+end

--- a/app/mailers/seller_mailer.rb
+++ b/app/mailers/seller_mailer.rb
@@ -49,4 +49,9 @@ class SellerMailer < ApplicationMailer
     @auction = auction
     mail(to: @auction.winning_bid.email, subject: 'PromoExchange Auction Product Confirm Received')
   end
+
+  def claim_payment(auction)
+    @auction = auction
+    mail(to: @auction.winning_bid.email, subject: 'PromoExchange Auction Claim Payment')
+  end
 end

--- a/app/views/seller_mailer/claim_payment.html.erb
+++ b/app/views/seller_mailer/claim_payment.html.erb
@@ -1,0 +1,8 @@
+<p>RE: Auction <%= @auction.reference %></p>
+
+<p>The auction is now complete. You are able to claim your payment from PromoExchange.</p>
+
+<p>Sincerely, <br/>
+The PromoExchange Team</p>
+
+<img src="http://thepromoexchange.com/images/px_logo.png" alt="PX Logo">

--- a/app/views/seller_mailer/claim_payment.text.erb
+++ b/app/views/seller_mailer/claim_payment.text.erb
@@ -1,0 +1,6 @@
+RE: Auction <%= @auction.reference %>
+
+The auction is now complete. You are able to claim your payment from PromoExchange.
+
+Sincerely,
+The PromoExchange Team

--- a/db/migrate/20151006174813_add_payment_claimed_to_auction.rb
+++ b/db/migrate/20151006174813_add_payment_claimed_to_auction.rb
@@ -1,0 +1,5 @@
+class AddPaymentClaimedToAuction < ActiveRecord::Migration
+  def change
+    add_column :spree_auctions, :payment_claimed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150924150527) do
+ActiveRecord::Schema.define(version: 20151006174813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,7 @@ ActiveRecord::Schema.define(version: 20150924150527) do
     t.string   "custom_pms_colors"
     t.string   "state"
     t.string   "tracking_number"
+    t.boolean  "payment_claimed",     default: false
   end
 
   add_index "spree_auctions", ["reference"], name: "index_spree_auctions_on_reference", unique: true, using: :btree

--- a/vendor/assets/javascripts/spree/frontend/dashboard/won_auction_tab.js
+++ b/vendor/assets/javascripts/spree/frontend/dashboard/won_auction_tab.js
@@ -92,6 +92,9 @@ $(function() {
 
             if(item.state === 'complete') {
               status_text = 'Completed';
+              if(item.payment_claimed === false ) {
+                status_text = 'Claim payment';
+              }
               action = simple_template({
                 value: ''
               });


### PR DESCRIPTION
:clipboard: 
- Sign in as buyer
- Create auction
- Transition auction to complete (confirm receipt)
- Sign in seller
- Ensure won auction displays auction as 'Claim Payment'
- Ensure eMail to seller telling them they can claim a payment was sent
