### PR TITLE
Change preferred rate to 3.99

### DIFF
--- a/app/models/spree/bid.rb
+++ b/app/models/spree/bid.rb
@@ -44,7 +44,7 @@ class Spree::Bid < Spree::Base
 
   def seller_fee
     rate = 0.0899
-    rate = 0.0299 if auction.preferred?(seller)
+    rate = 0.0399 if auction.preferred?(seller)
     (order.total * rate).round(2)
   end
 

--- a/app/models/spree/prebid.rb
+++ b/app/models/spree/prebid.rb
@@ -117,7 +117,7 @@ class Spree::Prebid < Spree::Base
 
     # Promo exchange commission
     px_commission = 0.0899
-    px_commission = 0.0299 if auction.preferred?(seller)
+    px_commission = 0.0399 if auction.preferred?(seller)
     log_debug(auction_data, "auction.preferred?(seller)=#{auction.preferred?(seller)}")
     log_debug(auction_data, "px_commission=#{px_commission}")
     auction_data[:running_unit_price] /= (1 - px_commission)

--- a/app/views/pages/_seller_how_it_works.html.erb
+++ b/app/views/pages/_seller_how_it_works.html.erb
@@ -47,7 +47,7 @@
       <li>You must have either been invited to PromoExchange by one of the Buyers in our community or have completed five transactions on the site and received positive reviews. </li>
     </ul>
   </div>
-  <p class="small-print">* 2.99% for Auctions you are invited to by the Buyer, 8.99% for all other Auctions.</p>
+  <p class="small-print">* 3.99% for Auctions you are invited to by the Buyer, 8.99% for all other Auctions.</p>
 
   <a class="btn btn-success hiw_btn" href="/dashboards" role="button">Start Selling</a>
 </div>

--- a/app/views/seller_mailer/seller_invite.html.erb
+++ b/app/views/seller_mailer/seller_invite.html.erb
@@ -1,6 +1,6 @@
 <p>Congratulations! <%= @buyer.company.present? ? @buyer.company : "#{@buyer.firstname} #{@buyer.lastname}" %> has invited you to participate in a PromoExchange auction.</p>
 
-<p>Accepting this invitation gives you a leg up on the competition because your PX fee is only 2.99% for this auction.</p>
+<p>Accepting this invitation gives you a leg up on the competition because your PX fee is only 3.99% for this auction.</p>
 
 <% if @type == 'non' %>
   <p><a href="<%= Spree::Store.first.url %>/pxusers/new?auction_ref=<%= Spree::Store.first.url %>/auctions/<%= @auction.id %>">Click here to accept the invitation and view the auction!</a></p>

--- a/app/views/seller_mailer/seller_invite.text.erb
+++ b/app/views/seller_mailer/seller_invite.text.erb
@@ -1,6 +1,6 @@
 Congratulations! <%= @buyer.company.present? ? @buyer.company : "#{@buyer.firstname} #{@buyer.lastname}" %> has invited you to participate in a PromoExchange auction.
 
-Accepting this invitation gives you a leg up on the competition because your PX fee is only 2.99% for this auction.
+Accepting this invitation gives you a leg up on the competition because your PX fee is only 3.99% for this auction.
 
 
 <% if @type == 'non' %>

--- a/app/views/spree/pxusers/_user_agreement.html.erb
+++ b/app/views/spree/pxusers/_user_agreement.html.erb
@@ -47,7 +47,7 @@
 
 <p><b>PromoExchange Authorized Agent</b> means the party authorized by PromoExchange to receive payment of the PromoExchange Fee.</p>
 
-<p><b>PromoExchange Fees</b> means a fee charged by PromoExchange to the Selected Seller equal to a percentage of the awarded amount. The PromoExchange Fees for a Preferred Seller is equal to 2.99% of the Bid, before shipping or taxes. For all other Sellers, the PromoExchange Fee is equal to 8.99% of the Bid before shipping or taxes; however, only the Selected Seller incurs PromoExchange Fees, which must be received by PromoExchange or the PromoExchange Authorized Agent by the Payment Due Date. Sellers not selected do not incur any PromoExchange Fees.</p>
+<p><b>PromoExchange Fees</b> means a fee charged by PromoExchange to the Selected Seller equal to a percentage of the awarded amount. The PromoExchange Fees for a Preferred Seller is equal to 3.99% of the Bid, before shipping or taxes. For all other Sellers, the PromoExchange Fee is equal to 8.99% of the Bid before shipping or taxes; however, only the Selected Seller incurs PromoExchange Fees, which must be received by PromoExchange or the PromoExchange Authorized Agent by the Payment Due Date. Sellers not selected do not incur any PromoExchange Fees.</p>
 
 <p><b>Promotional Merchandise</b> means any item PromoExchange allows a Buyer to create a Reverse Auction for a Request For Bids.</p>
 


### PR DESCRIPTION
:clipboard: 
- Sign in as buyer
- Create auction (invited seller)
- Ensure email received by seller is contains 3.99
- Ensure px markup is 3.99% for prebid
- Ensure User agreement contains 3.99%
- Ensure Seller how it works contains 3.99%
