### PR TITLE
Redisplay purchase history after confirm receipt

### DIFF
--- a/vendor/assets/javascripts/spree/frontend/dashboard/purchase_history_tab.js
+++ b/vendor/assets/javascripts/spree/frontend/dashboard/purchase_history_tab.js
@@ -180,7 +180,7 @@ $(function() {
         'X-Spree-Token': key
       },
       success: function(data) {
-        window.location = "/dashboards";
+        $('#purchase-history-tab').click();
       },
       error: function(data) {
         alert('Failed to Confirmed Receipt, please contact support');


### PR DESCRIPTION
:clipboard: 
- Create auction, progress to 'Confirm Receipt'
- Sign in as buyer
- Go to Purchase History
- Confirm receipt of package
- Ensure site stays on (refreshed) Purchase history tab
