### PR TITLE
Rate seller fix

### DIFF
--- a/app/mailers/seller_mailer.rb
+++ b/app/mailers/seller_mailer.rb
@@ -83,6 +83,6 @@ class SellerMailer < ApplicationMailer
 
   def review_rating(auction)
     @auction = auction
-    mail(to: @auction.winning_bid.email, subject: 'PromoExchange Auction Review Rating')
+    mail(to: @auction.winning_bid.email, subject: 'PromoExchange Auction Rate Seller')
   end
 end

--- a/vendor/assets/javascripts/spree/frontend/dashboard/purchase_history_tab.js
+++ b/vendor/assets/javascripts/spree/frontend/dashboard/purchase_history_tab.js
@@ -149,7 +149,7 @@ $(function() {
               if(!item.review){
                 action = simple_template({
                   value: action_template({
-                    url: '#', auction_id: item.id, auction_value: 'Review Rating', auction_class: 'review_rating'
+                    url: '#', auction_id: item.id, auction_value: 'Rate Seller', auction_class: 'review_rating'
                   })
                 });
               }


### PR DESCRIPTION
:clipboard: 
https://www.pivotaltracker.com/story/show/102848102
- Transition auction to complete (without rating)
- Button text should read 'Rate Seller'
