### PR TITLE
removed multiple deletion confirmation dialogue boxes

### DIFF
--- a/vendor/assets/javascripts/spree/frontend/dashboard/payment_method_tab.js
+++ b/vendor/assets/javascripts/spree/frontend/dashboard/payment_method_tab.js
@@ -32,7 +32,6 @@ $(function() {
         'X-Spree-Token': key
       },
       success: function(data) {
-        alert('Delete this entry');
         $this.parents('tr').hide('slow', function() {
           $(this).remove();
           $("body").css("cursor", "default");


### PR DESCRIPTION
- Sign In as buyer
- Click on "My Account" -> "Account Setting" -> "Payment Method" tab
- Receiving only one deletion confirmation dialogue box after remove account 
