### PR TITLE
Ticket#107784824

### DIFF
--- a/app/views/buyer_mailer/confirm_checking_account.html.erb
+++ b/app/views/buyer_mailer/confirm_checking_account.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-  <a href="<%= Spree::Store.current.url %>/dashboards?tab=payment_method">
+  <a href="http://<%= Spree::Store.current.url %>/dashboards?tab=payment_method">
     <button style="width: 120; height: 40px; font-size: 14px; background: #4CAE4C;">Dashboard</button>
   </a>
 </p>

--- a/app/views/buyer_mailer/confirm_order_expire.html.erb
+++ b/app/views/buyer_mailer/confirm_order_expire.html.erb
@@ -5,7 +5,7 @@ Because your time is valuable we’ve reopened the auction and all of the prior 
 All you have to do is click on the link below and you can select a new Seller immediately!</p>
 
 <p>
-  <a href="<%= Spree::Store.current.url %>/auctions/<%= @auction.id %>">
+  <a href="http://<%= Spree::Store.current.url %>/auctions/<%= @auction.id %>">
     <button style="width: 120; height: 40px; font-size: 14px; background: #4CAE4C;">Restart Auction</button>
   </a>
 </p>

--- a/app/views/buyer_mailer/new_request_idea.html.erb
+++ b/app/views/buyer_mailer/new_request_idea.html.erb
@@ -1,7 +1,9 @@
 <p> You recently requested product ideas from a swag specialist at the PromoExchange. We have put together several ideas for you to choose from by clicking here. </p>
 
-<p><a href="<%= Spree::Store.current.url %>/dashboards/">
-  <button style="width: 170px; height: 40px; font-size: 14px; background: #4CAE4C;">Click Here</button>
-</a></p>
+<p>
+  <a href="http://<%= Spree::Store.current.url %>/dashboards/">
+    <button style="width: 170px; height: 40px; font-size: 14px; background: #4CAE4C;">Click Here</button>
+  </a>
+</p>
 
 <%= render partial: 'email_signature' %>

--- a/app/views/buyer_mailer/product_delivered.html.erb
+++ b/app/views/buyer_mailer/product_delivered.html.erb
@@ -3,11 +3,11 @@
 <p>It looks like your order for <%= @auction.product.name %> from <%= @auction.winning_bid.seller.shipping_address.company %> was recently delivered.</p>
 <p>Please head over to your dashboard to confirm receipt and accuracy of the order.</p>
 <p>We’d also appreciate your participation in rating your Seller to ensure we are providing all of our Buyers the best Sellers in the industry to work with.</p>
-
-<p><a href="<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
-  <button style="width: 170px; height: 40px; font-size: 14px; background: #4CAE4C;">Confirm Receipt</button>
-</a></p>
-
+<p>
+  <a href="http://<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
+    <button style="width: 170px; height: 40px; font-size: 14px; background: #4CAE4C;">Confirm Receipt</button>
+  </a>
+</p>
 <p>The PromoExchange Team</p>
 
 <%= render partial: 'email_signature' %>

--- a/app/views/buyer_mailer/product_delivered.text.erb
+++ b/app/views/buyer_mailer/product_delivered.text.erb
@@ -3,6 +3,6 @@ RE: Auction <%= @auction.reference %>
 It looks like your order for <%= @auction.product.name %> from <%= @auction.winning_bid.seller.shipping_address.company %> was recently delivered.
 Please head over to your dashboard to confirm receipt and accuracy of the order.  We’d also appreciate your participation in rating your Seller to ensure we are providing all of our Buyers the best Sellers in the industry to work with.
 
-<a href="<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>"><button>Confirm Receipt</button></a>
+<a href="http://<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>"><button>Confirm Receipt</button></a>
 
 The PromoExchange Team

--- a/app/views/buyer_mailer/proof_available.html.erb
+++ b/app/views/buyer_mailer/proof_available.html.erb
@@ -4,9 +4,11 @@
 
 <p>Please click on the link below which will take you over to the project in your dashboard. You will be able to approve or reject the proof and provide feedback if necessary. </p>
 
-<p><a href="<%= Spree::Store.current.url %>/dashboards?tab=purchase_history">
-  <button style="width: 120; height: 40px; font-size: 14px; background: #4CAE4C;">Dashboard</button>
-</a></p>
+<p>
+  <a href="http://<%= Spree::Store.current.url %>/dashboards?tab=purchase_history">
+    <button style="width: 120; height: 40px; font-size: 14px; background: #4CAE4C;">Dashboard</button>
+  </a>
+</p>
 
 <p> The PromoExchange Team </p>
 

--- a/app/views/buyer_mailer/upload_proof.html.erb
+++ b/app/views/buyer_mailer/upload_proof.html.erb
@@ -4,7 +4,7 @@
 
 <p> After you have reviewed the attached proof, please click on the link below which will take you over to the project in your dashboard. You will be able to approve or reject the proof and provide feedback if necessary. </p>
 
-<p><a href="<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
+<p><a href="http://<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
   <button style="width: 120; height: 40px; font-size: 14px; background: #4CAE4C;">Approve Proof</button>
 </a></p>
 

--- a/app/views/seller_mailer/approve_proof.html.erb
+++ b/app/views/seller_mailer/approve_proof.html.erb
@@ -4,7 +4,7 @@
 
 <p> Please click on the button below. It will redirect you to the project on the Exchange to confirm the proof approval has been received and that the order is going into production. </p>
 
-<p><a href="<%= Spree::Store.current.url %>/dashboards?tab=won_auction">
+<p><a href="http://<%= Spree::Store.current.url %>/dashboards?tab=won_auction">
   <button style="width: 170; height: 40px; font-size: 14px; background: #4CAE4C;">Go to production</button>
 </a></p>
 

--- a/app/views/seller_mailer/initial_invoice.html.erb
+++ b/app/views/seller_mailer/initial_invoice.html.erb
@@ -42,8 +42,8 @@
 </table>
 
 <p>Your fee:</p>
-<p><a href="<%= Spree::Store.first.url %>/invoices/<%= @auction.id %>?tab=pay"><%= ((@auction.winning_bid.seller_fee / (1 - 0.029)) + 0.30).round(2) %> if paid by Credit Card</a></p>
-<p><a href="<%= Spree::Store.first.url %>/invoices/<%= @auction.id %>?tab=pay"><%= (@auction.winning_bid.seller_fee / (1 - 0.015)).round(2) %> if paid by Web Check/ACH</a></p>
+<p><a href="http://<%= Spree::Store.first.url %>/invoices/<%= @auction.id %>?tab=pay"><%= ((@auction.winning_bid.seller_fee / (1 - 0.029)) + 0.30).round(2) %> if paid by Credit Card</a></p>
+<p><a href="http://<%= Spree::Store.first.url %>/invoices/<%= @auction.id %>?tab=pay"><%= (@auction.winning_bid.seller_fee / (1 - 0.015)).round(2) %> if paid by Web Check/ACH</a></p>
 
 <p>Payment is due by <%= (Date.today + 10.days).strftime("%D") %></p>
 

--- a/app/views/seller_mailer/proof_needed_immediately.html.erb
+++ b/app/views/seller_mailer/proof_needed_immediately.html.erb
@@ -2,7 +2,7 @@
 
 <p> Looks like 2 days have passed and the virtual proof for the <%= @auction.product.name %> for <%= @auction.buyer.billing_address.full_name %> has not been uploaded for review. Please click on the link below and it will take you over to the project in your dashboard. If a proof is not uploaded immediately you will be at risk of losing the project. </p>
 
-<p><a href="<%= Spree::Store.current.url %>/dashboards?tab=won_auction">
+<p><a href="http://<%= Spree::Store.current.url %>/dashboards?tab=won_auction">
   <button style="width: 120; height: 40px; font-size: 14px; background: #4CAE4C;">Dashboard</button>
 </a></p>
 

--- a/app/views/seller_mailer/reject_proof.html.erb
+++ b/app/views/seller_mailer/reject_proof.html.erb
@@ -4,7 +4,7 @@
 
 <p><span style="background: #d3d3d3">" <%= @auction.proof_feedback %> "<span></p>
 
-<p><a href="<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
+<p><a href="http://<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
   <button style="width: 150; height: 40px; font-size: 14px; background: #4CAE4C;">Go Back</button>
 </a></p>
 

--- a/app/views/seller_mailer/seller_invite.html.erb
+++ b/app/views/seller_mailer/seller_invite.html.erb
@@ -5,9 +5,9 @@
 <p>Accepting this invitation gives you a leg up on the competition because your PX fee is only 3.99% for this auction.</p>
 
 <% if @type == 'non' %>
-  <p><a href="<%= Spree::Store.first.url %>/pxusers/new?auction_ref=<%= Spree::Store.first.url %>/auctions/<%= @auction.id %>">Click here to accept the invitation and view the auction!</a></p>
+  <p><a href="http://<%= Spree::Store.first.url %>/pxusers/new?auction_ref=<%= Spree::Store.first.url %>/auctions/<%= @auction.id %>">Click here to accept the invitation and view the auction!</a></p>
 <% else %>
-  <p><a href="<%= Spree::Store.first.url %>/auctions/<%= @auction.id %>">Click here to accept the invitation and view the auction!  </a></p>
+  <p><a href="http://<%= Spree::Store.first.url %>/auctions/<%= @auction.id %>">Click here to accept the invitation and view the auction!  </a></p>
 <% end %>
 
 <p>Good luck!<br/>

--- a/app/views/seller_mailer/waiting_for_confirmation.html.erb
+++ b/app/views/seller_mailer/waiting_for_confirmation.html.erb
@@ -50,7 +50,7 @@
 <p>Please contact the Buyer (<%= @auction.buyer.bill_address.phone %>/<%= @auction.buyer.email %>) by the end of the next business day to begin making delivery and payment arrangements.</p>
 <p>Failure to do so can cause this order to be awarded to another Seller and can jeopardize your membership in the PromoExchange community.</p>
 
-<p><a href="<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
+<p><a href="http://<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>">
   <button style="width: 120px; height: 40px; font-size: 14px; background: #4CAE4C;">Confirm</button>
 </a></p>
 

--- a/app/views/seller_mailer/waiting_for_confirmation.text.erb
+++ b/app/views/seller_mailer/waiting_for_confirmation.text.erb
@@ -42,7 +42,7 @@ Payment is due by <%= (Date.today + 10.days).strftime("%D") %>
 Please contact the Buyer (<%= @auction.buyer.bill_address.phone %>/<%= @auction.buyer.email %>) by the end of the next business day to begin making delivery and payment arrangements.
 Failure to do so can cause this order to be awarded to another Seller and can jeopardize your membership in the PromoExchange community.
 
-<a href="<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>"><button>Confirm</button></a>
+<a href="http://<%= Spree::Store.current.url %>/invoices/<%= @auction.id %>"><button>Confirm</button></a>
 
 <div class="email-signature">
   <div class="email-signature-icons">

--- a/app/views/spree/invoices/_buyer_actions.html.erb
+++ b/app/views/spree/invoices/_buyer_actions.html.erb
@@ -9,7 +9,7 @@
           <%= button_tag "Approve", style: "margin-left: 0px; margin-top: 6px;", class: "btn btn-success approve_proof", data: {id: @auction.id} %>
         </td>
         <td>
-          <%= button_tag "Request Changes", style: "margin-left: 0px;" class: "btn btn-danger reject_proof", data: {id: @auction.id} %>
+          <%= button_tag "Request Changes", style: "margin-left: 0px;", class: "btn btn-danger reject_proof", data: {id: @auction.id} %>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
- send email after trigger auction's event both side 
- on click button in email then redirect to purchase history / won auction page
- fixed about:blank page issue
