### PR TITLE
fixed art file logo pixelated issue

### DIFF
--- a/app/models/spree/logo.rb
+++ b/app/models/spree/logo.rb
@@ -2,13 +2,8 @@ class Spree::Logo < Spree::Base
   belongs_to :user
   validates :user_id, presence: true
 
-  has_attached_file :logo_file,
-    styles: {
-      thumb: '100x100>',
-      medium: '300x300>'
-    },
-    path: '/logo_file/:id/:style/:basename.:extension',
-    default_style: 'thumb'
+  has_attached_file :logo_file,path: '/logo_file/:id/:style/:basename.:extension'
+   
 
   validates_attachment_content_type :logo_file,
     content_type: %w(application/illustrator application/pdf image/x-eps image/vnd.adobe.photoshop)
@@ -18,7 +13,9 @@ class Spree::Logo < Spree::Base
   LOGO_FILE_NAME = { "pdf": "artwork/pdf.png", "ai": "artwork/ai.png", "eps": "artwork/eps.jpg",  "psd": "artwork/psd.jpg"}
 
   def artwork
-    extension = logo_file_file_name.split(".")[1].to_sym
-    "/assets/#{Spree::Logo::LOGO_FILE_NAME[extension]}"
+    if logo_file_file_name.present?
+      extension = logo_file_file_name.split(".")[1].to_sym
+      "/assets/#{Spree::Logo::LOGO_FILE_NAME[extension]}"
+    end  
   end
 end


### PR DESCRIPTION
- Sign in as a buyer
- Go to products page
- Create an auction for a product and add new art file as a logo and add it to auction
- At auction page download logo
- Accept bid of seller on above auction.
- On email sent to seller now logo attachment not pixelated. 
