### PR TITLE
create email for preferred seller

### DIFF
--- a/app/views/buyer_mailer/in_production.text.erb
+++ b/app/views/buyer_mailer/in_production.text.erb
@@ -8,5 +8,3 @@ Thank you for using the PromoExchange!
 We look forward to hearing about your experience.
 
 The PromoExchange Team
-
-<%= render partial: 'email_signature' %>


### PR DESCRIPTION
- As a buyer, create auction.
- after accept auction, send email to Seller that won the auction. 
- as a seller, after confirmed the order (by paying the PX fee), send email to Buyer that confirm the order.
- after upload proof, send email to Buyer that proof is available.
- as a buyer, after proof approve/reject, send email to Seller that proof has been approved or rejected.
- after approve/reject merchandise, send email to Seller that Buyer approves/rejects merchandise.
