### PR TITLE
fixed imprint method reset issue after error comes for an auction

### DIFF
--- a/app/views/spree/auctions/new.html.erb
+++ b/app/views/spree/auctions/new.html.erb
@@ -34,7 +34,7 @@
     <fieldset>
       <div class="form-group" id="imprint-methods">
         <%= f.label(:imprint_method_id, Spree.t(:imprint_method)) %>
-        <%= f.select :imprint_method_id, options_for_select(@imprint_methods),
+        <%= f.select :imprint_method_id, options_for_select(@imprint_methods, @auction.imprint_method_id),
           { prompt: 'Please Select' }, { class: 'form-control' } %>
       </div>
 


### PR DESCRIPTION
- Sign in as a buyer
- Go to auction create page
- Try to save auction with validation error(e.g. No logo selected)
- Now imprint method show the selected value instead of default
