### PR TITLE
products page sidebar UI fixed

### DIFF
--- a/app/views/spree/shared/_sidebar.html.erb
+++ b/app/views/spree/shared/_sidebar.html.erb
@@ -1,0 +1,4 @@
+<aside id="sidebar" class="col-sm-4 col-md-3" data-hook>
+  <%= render partial: 'spree/product/sidebar'%>
+</aside>
+


### PR DESCRIPTION
- Go to product listing page
- Click on one of the categories or colors
- Now deeper pages than the first have scrolling option for categories or color 
