### PR TITLE
HotFix, reference correct user registration error messages

### DIFF
--- a/app/views/spree/pxusers/new.html.erb
+++ b/app/views/spree/pxusers/new.html.erb
@@ -17,7 +17,7 @@
           <div class="tab-pane <%= active_me %>" id="buyer">
             <h4><%= Spree.t(:buyer_registration) %></h4>
             <%= form_for @pxuser, url: '/pxusers', method: :post, class: 'form' do |f| %>
-              <%= render 'spree/shared/error_messages', :object => @pxuser %>
+              <%= render 'spree/shared/user_error_messages', :object => @pxuser %>
               <%= render partial: 'spree/pxusers/address_form', locals: { f: f, :type => 'buyer' } %>
             <% end %>
           </div>
@@ -26,7 +26,7 @@
           <div class="tab-pane <%= active_me %>" id="seller">
             <h4><%= Spree.t(:seller_registration) %></h4>
             <%= form_for @pxuser, url: '/pxusers', method: :post, class: 'form' do |f| %>
-              <%= render 'spree/shared/error_messages', :object => @pxuser %>
+              <%= render 'spree/shared/user_error_messages', :object => @pxuser %>
               <%= render partial: 'spree/pxusers/address_form', locals: { f: f, :type => 'seller' } %>
             <% end %>
           </div>

--- a/app/views/spree/shared/_user_error_messages.html.erb
+++ b/app/views/spree/shared/_user_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% object = object.present? ? object : target %>
+<% if object.present? && object.errors.any? %>
+  <p class="alert alert-error">Errors</p>
+  <ul>
+    <% object.errors.each do |msg| %>
+      <li class="error"><%= msg %></li>
+    <% end %>
+  </ul>
+<% end %>


### PR DESCRIPTION
HOTFIX

https://www.pivotaltracker.com/story/show/111781958

User registration error object was referencing a nil.

New error message template that references correct object.
