### PR TITLE
Add missing migration to database

### DIFF
--- a/db/migrate/20160501223554_add_default_for_production_time.rb
+++ b/db/migrate/20160501223554_add_default_for_production_time.rb
@@ -1,0 +1,5 @@
+class AddDefaultForProductionTime < ActiveRecord::Migration
+  def change
+    change_column :spree_products, :production_time, :integer, default: 7
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160501201523) do
+ActiveRecord::Schema.define(version: 20160501223554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -764,7 +764,7 @@ ActiveRecord::Schema.define(version: 20160501201523) do
     t.decimal  "max_retail"
     t.integer  "min_qty"
     t.decimal  "min_retail"
-    t.integer  "production_time"
+    t.integer  "production_time",                     default: 7
     t.boolean  "rush_available"
     t.string   "supplier_display_name"
     t.string   "supplier_display_num"


### PR DESCRIPTION
https://trello.com/c/FpNhJq0s/1317-add-missing-migration-adddefaultforproductiontime-to-production

After deployment this migration will be run by heruko
# Test Plan
1. Ensure the codeship build ran the `db:migrate` successfully in the build log.

⚠️ You must have heroku toolbelt installed and configured with the correct access and responsibilty.
1. From CLI run `heroku run rails c --app px-batman`. EXTREME CARE
1. Run `Spree::Product.first.production_time`
1. Ensure result is 7
