### PR TITLE
Fix login crash for new user

### DIFF
--- a/app/views/spree/shared/_header.html.erb
+++ b/app/views/spree/shared/_header.html.erb
@@ -9,12 +9,12 @@
           <%= render :partial => 'spree/shared/nav_bar' %>
           <%= render :partial => 'spree/shared/main_nav_bar' if store_menu? %>
           <% if spree_current_user %>
-            <p class = "header-sign-in" > Hello, <%= spree_current_user.bill_address.first_name %> </p>
+            <p class = "header-sign-in" > Hello, <%= spree_current_user.shipping_name %> </p>
           <% end %>
         </div>
         <div class="col-md-2">
           <% if spree_current_user %>
-            <p class = "header-sign-in" > Hello, <%= spree_current_user.bill_address.first_name %> </p>
+            <p class = "header-sign-in" > Hello, <%= spree_current_user.shipping_name %> </p>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
https://trello.com/c/dlkyYzKG

Prevent crash on login for new users.
### Testplan
1. Create new buyer account in admin panels
2. Ensure you can login with the new user.
