### PR TITLE
Put guards around purchase migrations

### DIFF
--- a/db/migrate/20160910001001_add_purchase_table.rb
+++ b/db/migrate/20160910001001_add_purchase_table.rb
@@ -1,14 +1,16 @@
 class AddPurchaseTable < ActiveRecord::Migration
   def change
-    create_table :spree_purchases do |t|
-      t.integer :quantity, null: false
-      t.integer :product_id, null: false
-      t.integer :logo_id, null: false
-      t.integer :imprint_method_id, null: false
-      t.integer :main_color_id, null: false
-      t.integer :buyer_id, null: false
-      t.integer :order_id
-      t.integer :shipping_option, null: false
+    unless ActiveRecord::Base.connection.table_exists? 'spree_purchases'
+      create_table :spree_purchases do |t|
+        t.integer :quantity, null: false
+        t.integer :product_id, null: false
+        t.integer :logo_id, null: false
+        t.integer :imprint_method_id, null: false
+        t.integer :main_color_id, null: false
+        t.integer :buyer_id, null: false
+        t.integer :order_id
+        t.integer :shipping_option, null: false
+      end
     end
   end
 end

--- a/db/migrate/20160911213227_add_address_id_to_purchases.rb
+++ b/db/migrate/20160911213227_add_address_id_to_purchases.rb
@@ -1,5 +1,7 @@
 class AddAddressIdToPurchases < ActiveRecord::Migration
   def change
-    add_column :spree_purchases, :address_id, :integer, null: false
+    unless ActiveRecord::Base.connection.column_exists?(:spree_purchases, :address_id)
+      add_column :spree_purchases, :address_id, :integer, null: false
+    end
   end
 end

--- a/db/migrate/20160913004450_add_reference_to_purchase.rb
+++ b/db/migrate/20160913004450_add_reference_to_purchase.rb
@@ -1,5 +1,7 @@
 class AddReferenceToPurchase < ActiveRecord::Migration
   def change
-    add_column :spree_purchases, :reference, :string, default: ""
+    unless ActiveRecord::Base.connection.column_exists?(:spree_purchases, :reference)
+      add_column :spree_purchases, :reference, :string, default: ""
+    end
   end
 end


### PR DESCRIPTION
Place guard statements around `purchase` related migrations.

Benign most of the time
