### PR TITLE
Store specific views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,11 @@ class ApplicationController < ActionController::Base
     @current_company_store ||= Spree::CompanyStore.find(session[:company_store_id])
   end
 
+  def store_view_setup
+    return if current_company_store.nil?
+    prepend_view_path "app/views/#{current_company_store.slug}_store/"
+  end
+
   def ping
     render json: { ping: 'pong' }
   end

--- a/app/controllers/spree/company_store_controller.rb
+++ b/app/controllers/spree/company_store_controller.rb
@@ -1,6 +1,7 @@
 class Spree::CompanyStoreController < Spree::StoreController
   layout 'company_store_layout'
   before_action :fetch_company_store, only: [:show]
+  before_action :store_view_setup, only: [:show]
 
   def index
     company_store_id = ENV['COMPANYSTORE_ID']

--- a/app/controllers/spree/purchases_controller.rb
+++ b/app/controllers/spree/purchases_controller.rb
@@ -1,5 +1,6 @@
 class Spree::PurchasesController < Spree::StoreController
   layout 'company_store_layout'
+  before_action :store_view_setup
 
   def new
     # TODO: Allow creation with shipping_option

--- a/app/views/gooten_store/spree/company_store/show.html.erb
+++ b/app/views/gooten_store/spree/company_store/show.html.erb
@@ -1,0 +1,20 @@
+<h1>I AM GOOTEN</h1>
+
+<div class="row">
+  <% @products.each do |product| %>
+    <div class="col-md-4 cs-product">
+      <%= link_to large_image(product, { itemprop: 'image', class: 'cs-image' }), main_app.new_purchase_path(purchase: { product_id: product.id }), itemprop: 'url' %>
+      <div class="cs-product-text text-center"><%= product.name %></div>
+      <div class="cs-product-text text-center cs-lowest-bid"><%= number_to_currency(product.best_price()[:best_price].to_f / product.last_price_break_minimum) %></div>
+    </div>
+  <% end %>
+</div>
+
+<% if @current_company_store.slug != 'gooten' %>
+  <div class="product-ideas text-center">
+    <p>Can't find the product you are looking for? Let the PromoExchange swag pros provide you with some custom ideas.</p>
+    <%= button_tag "Inspire me with new product ideas!", class: 'btn btn-success cs-button', id: 'inspire-me', data: { toggle: 'modal', target: '#inspire-me-request' } %>
+  </div>
+
+  <%= render partial: 'spree/company_store/inspire_me_modal' %>
+<% end %>

--- a/app/views/gooten_store/spree/purchases/new.html.erb
+++ b/app/views/gooten_store/spree/purchases/new.html.erb
@@ -1,0 +1,82 @@
+<%- api_key = @current_company_store.buyer.spree_api_key unless @current_company_store.nil? %>
+<%- api_key = spree_current_user.spree_api_key if api_key.nil? && spree_current_user.present? %>
+<%- is_gooten = @current_company_store.slug == 'gooten' %>
+
+<h1>I AM GOOTEN</h1>
+
+<div class="cs-page row" id="new-purchase" data-key="<%= api_key %>">
+  <div class="col-md-6">
+    <% @product.images.each_with_index do |image, index| %>
+      <% if index.zero? %>
+        <%= large_image(@product, itemprop: 'image', class: 'main-product-image mobile-image center-block') %><br/>
+      <% else %>
+        <%= image_tag image.attachment.url(:small) %>
+      <% end %>
+    <% end %>
+
+    <br /><br />
+
+    <% if is_gooten %>
+      <div class="well">
+        <%= form_for @purchase.logo, multipart: true, url: '/logos', class: 'form' do |f| %>
+          <div class="form-group">
+            <h2 class="text-center"><%= Spree.t(:logo) %></h2>
+            <%= f.file_field :logo, class: 'logo-upload' %>
+          </div>
+
+          <br />
+
+          <%= image_tag 'star-1.png', class: 'hidden logo-to-upload text-center' %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="col-md-6">
+    <h1 id='new_purchase_name'><%= @product.name %></h1>
+
+    <%= form_for @purchase, url: main_app.purchases_path, class: 'form' do |f| %>
+      <%= f.hidden_field :company_store_slug, value: @current_company_store.slug %>
+      <%= f.hidden_field :product_id, value: @product.id %>
+      <%= f.hidden_field :buyer_id, value: @purchase.buyer_id %>
+
+      <% if @purchase.errors.any? %>
+        <p class="alert alert-error">Errors</p>
+        <ul>
+          <% @purchase.errors.full_messages.each do |message| %>
+            <li class="error"><%= message %></li>
+          <% end %>
+        </ul>
+      <% end %>
+
+      <fieldset>
+        <%= render partial: 'imprint_method', locals: { f: f }%>
+        <%= render partial: 'logos', locals: { f: f } %>
+        <%= render partial: 'main_color', locals: { f: f } %>
+        <% if is_gooten %>
+          <%= render partial: 'quantity', locals: { f: f } %>
+          <%= render partial: 'address', locals: { f: f } %>
+        <% else %>
+          <%= render partial: 'price_breaks', locals: { f: f } %>
+          <div class="<%= 'col-md-4' unless @product.wearable? %>">
+            <%= render partial: 'quantity', locals: { f: f } %>
+          </div>
+          <div class="<%= 'col-md-8' unless @product.wearable? %>">
+            <%= render partial: 'address_drop', locals: { f: f } %>
+          </div>
+        <% end %>
+        <p id='mobile-align-center'>Estimated delivery date: <%= content_tag(:span, '--', id: 'ship_date') %></p>
+        <%= render partial: 'shipping_options', locals: { f: f } %>
+        <%= render partial: 'active_price', locals: { f: f } %>
+        <%= render partial: 'buttons', locals: { f: f } %>
+      </fieldset>
+    <% end %>
+
+    <% if @product.description %>
+      <p id='mobile-align-center'><strong>Description:</strong> <%= @product.description %></p>
+    <% end %>
+
+    <p id='mobile-align-center'><strong>Factory:</strong> <%= @product.original_supplier.name %></p>
+    <p id='mobile-align-center'><strong>SKU:</strong> <%= @product.sku %></p>
+  </div>
+</div>


### PR DESCRIPTION
See: https://trello.com/c/47W0Vd1R

Two places for store specific views.

1. `company_store/show`
1. `purchases/new`

- Partial still work (fall back to default)
- Other actions and specific partials can be added

Because of the Spree engine the actual path has to be suffixed with spree

`app/views/#{current_company_store.slug}/spree/company_store`

and

`app/views/#{current_company_store.slug}/spree/purchases`

### Testplan
1. Visit gooten store, ensure *I AM GOOTEN* is displayed on front page
1. Visit anchorfree store, ensure *I AM GOOTEN* is **not** displayed
1. Visit gooten product purchase page, ensure *I AM GOOTEN* is displayed
1. Visit anchorfree  product purchase, ensure *I AM GOOTEN* is **not** displayed