### PR TITLE
Do not calculate price breaks for non traditional stores

### DIFF
--- a/app/controllers/spree/purchases_controller.rb
+++ b/app/controllers/spree/purchases_controller.rb
@@ -23,10 +23,12 @@ class Spree::PurchasesController < Spree::StoreController
       sizes: []
     )
 
-    @product.price_breaks.each do |price_break|
-      lowest_range = price_break.split('..')[0].gsub(/\D/, '').to_i
-      best_price = @product.best_price(quantity: lowest_range)[:best_price].to_f / lowest_range
-      @purchase.price_breaks << [lowest_range, best_price]
+    if @current_company_store.traditional?
+      @product.price_breaks.each do |price_break|
+        lowest_range = price_break.split('..')[0].gsub(/\D/, '').to_i
+        best_price = @product.best_price(quantity: lowest_range)[:best_price].to_f / lowest_range
+        @purchase.price_breaks << [lowest_range, best_price]
+      end
     end
 
     render :new


### PR DESCRIPTION
Do not calculate price breaks if the store is non-traditional

## Testplan
- https://px-batman-stage-pr-802.herokuapp.com/company_store/ffvc
- https://px-batman-stage-pr-802.herokuapp.com/company_store/pavia
- https://px-batman-stage-pr-802.herokuapp.com/company_store/gooten

`[:hybrid, :traditional:, :gooten].each do`

1. Go to product, ensure price grid populated if present
1. Create purchase for wearable and non-wearable pages
1. Ensure purchase page reflects quoted price

`end`