### PR TITLE
Reinstate Slack messages and allow channel configuration via env

### DIFF
--- a/app/controllers/spree/purchases_controller.rb
+++ b/app/controllers/spree/purchases_controller.rb
@@ -125,11 +125,11 @@ class Spree::PurchasesController < Spree::StoreController
     )
 
     Resque.enqueue(SendInvoice, order_id: @order.id)
-    # if @order.purchase.image.present?
-    #   SLACK.ping "Order for $#{@order.item_total} by #{@order.user.email}: #{@order.purchase.image.attachment.url}"
-    # else
-    #   SLACK.ping "Order for $#{@order.item_total} by #{@order.user.email}"
-    # end
+    if @order.purchase.image.present?
+      SLACK.ping "Order for $#{@order.item_total} by #{@order.user.email}: #{@order.purchase.image.attachment.url}"
+    else
+      SLACK.ping "Order for $#{@order.item_total} by #{@order.user.email}"
+    end
 
     redirect_to "/company_store/#{current_company_store.slug}"
   rescue StandardError => e

--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -1,1 +1,2 @@
-SLACK = Slack::Notifier.new ENV['SLACK_URL']
+# N.B. ENV['SLACK_CHANNEL'] SHOULD NOT BE PREFIXED WITH # - i.e. use foobar for channel #foobar
+SLACK = Slack::Notifier.new ENV['SLACK_URL'], channel: "##{ENV['SLACK_CHANNEL'].blank? ? "px-orders" : ENV['SLACK_CHANNEL']}"


### PR DESCRIPTION
See: https://trello.com/c/CnuIPYDs

## Testplan
1. Ensure NO environment set for `SLACK_CHANNEL`
1. ** NOTIFY ** `#px-orders` channel in slack that you are testing
1. Purchase an item in any store, complete credit card purchase. [Test Credit Card Numbers](https://stripe.com/docs/testing#cards)
1. Ensure purchase message sent to `#px-orders` channel in slack.
1. Set environment `SLACK_CHANNEL` to `#engineering` (NOTE. Prefixed #)
1. Purchase an item in any store, complete credit card purchase. 
1. Ensure purchase message sent to `#px-orders` channel in slack.
1. Set environment `SLACK_CHANNEL` to `engineering` (NOTE. NO prefixed #)
1. Purchase an item in any store, complete credit card purchase. 
1. Ensure purchase message sent to `#engineering` channel in slack.
1. ** NOTIFY ** `#px-orders` channel in slack that you are done testing

