### PR TITLE
Check Stripe location setting during initialization

### DIFF
--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -3,12 +3,12 @@ Rails.configuration.stripe = {
   secret_key:      ENV['STRIPE_SECRET_KEY']
 }
 
-pk_env = Rails.configuration.stripe[:publishable_key][3..6]
-sk_env = Rails.configuration.stripe[:secret_key][3..6]
-if ( pk_env == 'test' || sk_env == 'test' )
-  raise "Attempting to run TEST stripe in production" if Rails.env.production?
-else
+pk_env = Rails.configuration.stripe[:publishable_key] && Rails.configuration.stripe[:publishable_key][3..6]
+sk_env = Rails.configuration.stripe[:secret_key] && Rails.configuration.stripe[:secret_key][3..6]
+if ( pk_env == 'live' || sk_env == 'live' )
   raise "Attempting to run LIVE stripe in non production" unless Rails.env.production?
+else
+  raise "Attempting to run TEST stripe in production" if pk_env && sk_env && Rails.env.production?
 end
 raise "Both Stripe settings must point to same location" if sk_env != pk_env
 


### PR DESCRIPTION
See: https://trello.com/c/obEgqArz

## Testplan
1. Using heroku app settings, set prefix on variable `STRIPE_PUBLISHABLE_KEY` to `pk_live`
1. Ensure app fails to restart
1. Using heroku app settings, set prefix on variable `STRIPE_SECRET_KEY` to `sk_live`
1. Ensure app fails to restart
1. Reset `STRIPE_PUBLISHABLE_KEY` to `pk_test` and `STRIPE_SECRET_KEY` prefix to `sk_test`
1. Ensure app restarts
1. Complete purchase, ensure TEST version is used for CC purchase.
