### PR TITLE
Do not show need it now if already displaying options

### DIFF
--- a/vendor/assets/javascripts/spree/frontend/purchase/new.js
+++ b/vendor/assets/javascripts/spree/frontend/purchase/new.js
@@ -132,6 +132,7 @@ $(function() {
   })();
 
   function set_summary() {
+    return;
     var main_image = $('.main-product-image').first();
     var summary_image = $('.summary-product-image').first();
     $.each(["src","alt"], function(_i, s){


### PR DESCRIPTION
1. Once price is calculated on main last screen
1. Press need it now -> Shipping options display
1. Recalc price (addr/quantity/quality) etc. anything that causes a recalc
1. Need it now link reappears

Need it now should not reappear
